### PR TITLE
actorOf functions return effects

### DIFF
--- a/src/Akkling/Spawning.fs
+++ b/src/Akkling/Spawning.fs
@@ -130,12 +130,11 @@ module Spawn =
     /// Wraps provided function with actor behavior. 
     /// It will be invoked each time, an actor will receive a message. 
     /// </summary>
-    let actorOf (fn : 'Message -> unit) (mailbox : Actor<'Message>) : Behavior<'Message> = 
+    let actorOf (fn : 'Message -> #Effect) (mailbox : Actor<'Message>) : Behavior<'Message> = 
         let rec loop() = 
             actor { 
                 let! msg = mailbox.Receive()
-                fn msg
-                return! loop()
+                return fn msg 
             }
         loop()
     
@@ -143,11 +142,25 @@ module Spawn =
     /// Wraps provided function with actor behavior. 
     /// It will be invoked each time, an actor will receive a message. 
     /// </summary>
-    let actorOf2 (fn : Actor<'Message> -> 'Message -> unit) (mailbox : Actor<'Message>) : Behavior<'Message> = 
+    let actorOf2 (fn : Actor<'Message> -> 'Message -> #Effect) (mailbox : Actor<'Message>) : Behavior<'Message> = 
         let rec loop() = 
-            actor { 
+            actor {
                 let! msg = mailbox.Receive()
-                fn mailbox msg
-                return! loop()
+                return fn mailbox msg
             }
         loop()
+
+    /// <summary>
+    /// Returns an actor effect causing no changes in message handling pipeline.
+    /// </summary>
+    let inline ignored (_: 'Any) : Effect = ActorEffect.Ignore :> Effect
+
+    /// <summary>
+    /// Returns an actor effect causing messages to become unhandled.
+    /// </summary>
+    let inline unhandled (_: 'Any) : Effect = ActorEffect.Unhandled :> Effect
+
+    /// <summary>
+    /// Returns an actor effect causing actor to stop.
+    /// </summary>
+    let inline stop (_: 'Any) : Effect = ActorEffect.Stop :> Effect

--- a/tests/Akkling.Tests/Actors.fs
+++ b/tests/Akkling.Tests/Actors.fs
@@ -16,7 +16,7 @@ open Xunit
 
 [<Fact(Skip ="fix MethodMissing")>]
 let ``Actor defined by recursive function responds on series of primitive messagess`` () : unit = testDefault <| fun tck -> 
-    let echo = spawn tck "actor" (actorOf2 <| fun mailbox msg -> mailbox.Sender() <! msg)
+    let echo = spawn tck "actor" (actorOf2 <| fun mailbox msg -> mailbox.Sender() <! msg |> ignored)
 
     echo <! 1
     echo <! 2

--- a/tests/Akkling.Tests/Api.fs
+++ b/tests/Akkling.Tests/Api.fs
@@ -72,7 +72,7 @@ let ``can serialize discriminated unions``() =
 [<Fact>]
 let ``can serialize typed actor ref``() = 
     use sys = System.create "system" (Configuration.defaultConfig())
-    let echo = spawn sys "echo" <| actorOf2 (fun mailbox msg -> mailbox.Sender() <! msg)
+    let echo = spawn sys "echo" <| actorOf2 (fun mailbox msg -> mailbox.Sender() <! msg |> ignored)
     let serializer = sys.Serialization.FindSerializerFor echo
     let bytes = serializer.ToBinary echo
     let des = serializer.FromBinary(bytes, echo.GetType()) :?> IActorRef<string>
@@ -89,6 +89,7 @@ let testBehavior (mailbox:Actor<_>) msg =
     match msg with
     | Succeed("a-11", Inner(11, "a-12")) -> mailbox.Sender() <! msg
     | _ -> mailbox.Sender() <! Fail  
+    |> ignored
 
 [<Fact(Skip ="fix MethodMissing")>]
 let ``can serialize and deserialize discriminated unions over remote nodes`` () =   


### PR DESCRIPTION
### Motivation

After bringing up Effects to Akkling, some of the behaviors require them in order to perform certain actions (like actor stopping or unhandling a message). This was pretty limiting for `actorOf` and `actorOf2` functions, which up to this moment returned `unit` and there was no option to stop an actor or unhandle the message from these functions.
### Change

`actorOf` and `actorOf2` now return and `Effect` instead of `unit`. No effect can be achieved by forwarding operator to `ignored` function, which returns empty effect. All effect functions:
- `ignored` - no additional action is performed
- `unhandled` - message becomes unhandled
- `stop` - actor is stopped and terminated.
### Example

``` fsharp
let a = spawn system "actor-name" (actorOf (fun m -> printfn "%A" m |> ignored))
```
