### PR TITLE
Ask returns AskResult<_>

### DIFF
--- a/examples/persistence.fsx
+++ b/examples/persistence.fsx
@@ -47,4 +47,4 @@ counter <! Command Inc
 counter <! Command Inc
 counter <! Command Dec
 async { let! reply = counter <? Command GetState
-        printfn "Current state of %A: %i" counter reply } |> Async.RunSynchronously
+        printfn "Current state of %A: %i" counter reply.Value } |> Async.RunSynchronously

--- a/tests/Akkling.Tests/Api.fs
+++ b/tests/Akkling.Tests/Api.fs
@@ -116,6 +116,6 @@ let ``can serialize and deserialize discriminated unions over remote nodes`` () 
     let aref = 
         spawne [SpawnOption.Deploy (Deploy(RemoteScope (Address.Parse "akka.tcp://server-system@localhost:9911")))] client "a-1" <@ actorOf2 testBehavior @> 
     let msg = Succeed("a-11", Inner(11, "a-12"))
-    let response : OuterUnion = aref <? msg |> Async.RunSynchronously
-    response
+    let response : AskResult<OuterUnion> = aref <? msg |> Async.RunSynchronously
+    response.Value
     |> equals msg


### PR DESCRIPTION
### Motivation

Until now `Ask` method and ask operator `<?` returned requested value directly. That often resulted with some kind of exceptions throws and risk of unhandled exception. 
### Changes

This PR changed ask to return `AskResult<'Result>`, which can be either `Ok<'Result>` or `Error`. This way we have explicit mechanism to deal with exceptions. Moreover, AskResult is automatically propagated if forwarded, which make it useful for railway-oriented-programming. In case when you don't want to deal with `Ok` \ `Error` distinction, use `AskResult.Value` to get the value directly.

Credits to @jtmueller.

/cc #25
