### PR TITLE
Modified spawning mechanism to Props-based

### DIFF
--- a/examples/basic.fsx
+++ b/examples/basic.fsx
@@ -11,7 +11,7 @@ open Akka.Actor
 
 let system = System.create "basic-sys" <| Configuration.defaultConfig()
 
-let helloRef = spawn system "hello-actor" <| fun m ->
+let behavior (m:Actor<_>) = 
     let rec loop () = actor {
         let! msg = m.Receive ()
         match msg with
@@ -21,7 +21,18 @@ let helloRef = spawn system "hello-actor" <| fun m ->
             printfn "%s" x
             return! loop ()
     }
-    loop ()
+    loop () 
+
+// First approach - using explicit behavior loop
+let helloRef = spawnAnonymous system (props behavior)
+
+// Second approach - using implicits
+let helloBehavior = function
+    | "stop" -> stop ()
+    | "unhandle" -> unhandled ()
+    | x -> printfn "%s" x |> ignored 
+
+let helloRef2 = spawn system "hello-actor2" <| props (actorOf helloBehavior)
     
 helloRef <! "ok"
 helloRef <! "unhandle"

--- a/examples/io.fsx
+++ b/examples/io.fsx
@@ -27,16 +27,16 @@ let handler connection = fun (ctx: Actor<obj>) ->
     loop ()
 
 let endpoint = IPEndPoint(IPAddress.Loopback, 5000)
-let listener = spawn system "listener" <| fun m ->
+let listener = spawn system "listener" <| props(fun m ->
     IO.Tcp(m) <! TcpMessage.Bind(m.Self, endpoint, 100)
     let rec loop () = actor {
         let! (msg: obj) = m.Receive ()
         match msg with
         | Connected(remote, local) ->
             let conn = m.Sender ()
-            conn <! TcpMessage.Register(spawn m null (handler conn))
+            conn <! TcpMessage.Register(spawn m null (props(handler conn)))
             return! loop ()
         | _ -> return Unhandled
     }
-    loop ()
+    loop ())
     

--- a/examples/lifecycle.fsx
+++ b/examples/lifecycle.fsx
@@ -11,7 +11,7 @@ open Akka.Actor
 
 let system = System.create "basic-sys" <| Configuration.defaultConfig()
 
-let aref = spawn system "hello-actor" <| fun m ->
+let aref = spawn system "hello-actor" <| props(fun m ->
     let rec loop () = actor {
         let! (msg: obj) = m.Receive ()
         match msg with
@@ -23,7 +23,7 @@ let aref = spawn system "hello-actor" <| fun m ->
         | x -> printfn "%A" x
         return! loop ()
     }
-    loop ()
+    loop ())
 
 let sref = retype aref
 sref <! "ok"

--- a/examples/persistence.fsx
+++ b/examples/persistence.fsx
@@ -27,7 +27,7 @@ type CounterMessage =
     | Event of CounterChanged
 
 let counter = 
-    spawnPersist system "counter-1" <| fun mailbox -> 
+    spawn system "counter-1" <| propsPersist(fun mailbox -> 
         let rec loop state = 
             actor { 
                 let! msg = mailbox.Receive()
@@ -41,7 +41,7 @@ let counter =
                     | Inc -> return Persist (Event { Delta = 1 })
                     | Dec -> return Persist (Event { Delta = -1 })
             }
-        loop 0
+        loop 0)
         
 counter <! Command Inc
 counter <! Command Inc

--- a/examples/remote.fsx
+++ b/examples/remote.fsx
@@ -34,11 +34,10 @@ let client = System.create "client" <| Configuration.parse """
     }   
 """
 
-let spawnRemote addr sys name actor = 
-    let options = [SpawnOption.Deploy(Deploy(RemoteScope(Address.Parse addr)))]
-    spawne options sys name actor
+let remoteProps addr actor = { propse actor with Deploy = Some (Deploy(RemoteScope(Address.Parse addr))) }
 
-let printer = spawnRemote "akka.tcp://server@localhost:4500" client "remote-actor" <@ actorOf2 (fun ctx msg -> printfn "%A received: %s" ctx.Self msg) @>
+let printer = 
+    spawn client "remote-actor" (remoteProps "akka.tcp://server@localhost:4500" <@ actorOf2 (fun ctx msg -> printfn "%A received: %s" ctx.Self msg |> ignored) @>)
 
 printer <! "hello"
 printer <! "world"

--- a/src/Akkling/Akkling.fsproj
+++ b/src/Akkling/Akkling.fsproj
@@ -10,7 +10,7 @@
     <RootNamespace>Akkling</RootNamespace>
     <AssemblyName>Akkling</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
     <Name>Akkling</Name>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -69,6 +69,7 @@
     <Compile Include="ActorBuilder.fs" />
     <Compile Include="Linq.fs" />
     <Compile Include="FaultHandling.fs" />
+    <Compile Include="Props.fs" />
     <Compile Include="Spawning.fs" />
     <Compile Include="Behaviors.fs" />
     <Compile Include="Schedulers.fs" />

--- a/src/Akkling/Props.fs
+++ b/src/Akkling/Props.fs
@@ -1,0 +1,138 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Spawning.fs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+//     Copyright (C) 2015 Bartosz Sypytkowski <gttps://github.com/Horusiath>
+// </copyright>
+//-----------------------------------------------------------------------
+
+[<AutoOpen>]
+module Akkling.Props
+
+open System
+open Akka.Actor
+open Microsoft.FSharp.Quotations
+open Microsoft.FSharp.Linq.QuotationEvaluation
+
+let internal exprSerializer = Nessos.FsPickler.FsPickler.CreateBinarySerializer()
+
+/// <summary>
+/// Typed props are descriptors of how particular actor should be instantiated.
+/// </summary>
+type Props<'Message> = 
+    { 
+      /// <summary>
+      /// INTERNAL API.
+      /// </summary>
+      ActorType: Type
+
+      /// <summary>
+      /// INTERNAL API.
+      /// </summary>
+      Receiver: obj
+
+      /// <summary>
+      /// Config key to dispatcher responsible for managing current actor's threading.
+      /// </summary>
+      Dispatcher: string option
+
+      /// <summary>
+      /// Config key to mailbox type used by current actor.
+      /// </summary>
+      Mailbox: string option
+
+      /// <summary>
+      /// Deploy settings of the current actor.
+      /// </summary>
+      Deploy: Deploy option
+
+      /// <summary>
+      /// Router settings in case when current actor is used in router configuration.
+      /// </summary>
+      Router: Akka.Routing.RouterConfig option
+
+      /// <summary>
+      /// Custom supervision strategy used by current actor.
+      /// </summary>
+      SupervisionStrategy: SupervisorStrategy option } 
+
+    member this.ToProps () : Akka.Actor.Props = this.ToProps true
+    member internal this.ToProps (withReceiver: bool) : Akka.Actor.Props = 
+        let mutable p = if withReceiver then Props.Create(this.ActorType, [| this.Receiver |]) else Props.Create(this.ActorType)
+        p <- match this.Dispatcher with
+                | Some dispatcher -> p.WithDispatcher dispatcher
+                | _ -> p
+        p <- match this.Mailbox with
+                | Some mailbox -> p.WithMailbox mailbox
+                | _ -> p
+        p <- match this.Deploy with
+                | Some deploy -> p.WithDeploy deploy
+                | _ -> p
+        p <- match this.Router with
+                | Some router -> p.WithRouter router
+                | _ -> p
+        p <- match this.SupervisionStrategy with
+                | Some supervisionStrategy -> p.WithSupervisorStrategy supervisionStrategy
+                | _ -> p
+        p
+
+    static member Create<'Actor, 'Context, 'Message when 'Actor :> ActorBase>(receive: 'Context -> Behavior<'Message>) : Props<'Message> = 
+        { ActorType = typeof<'Actor>
+          Receiver = receive
+          Dispatcher = None
+          Mailbox = None
+          Deploy = None
+          Router = None
+          SupervisionStrategy = None }
+
+    static member Create<'Actor, 'Context, 'Message when 'Actor :> ActorBase>(expr: Expr<('Context -> Behavior<'Message>)>) : Props<'Message> = 
+        { ActorType = typeof<'Actor>
+          Receiver = expr
+          Dispatcher = None
+          Mailbox = None
+          Deploy = None
+          Router = None
+          SupervisionStrategy = None }
+
+    static member From(props: Props) : Props<'Message> =
+        { ActorType = props.Type
+          Receiver = props.Arguments.[0]
+          Deploy = Some props.Deploy
+          Dispatcher = if props.Dispatcher = Deploy.NoDispatcherGiven then None else Some props.Dispatcher
+          Mailbox = if props.Mailbox = Deploy.NoMailboxGiven then None else Some props.Mailbox
+          Router =  if props.RouterConfig = Akka.Routing.RouterConfig.NoRouter then None else Some props.RouterConfig
+          SupervisionStrategy = if props.SupervisorStrategy = null then None else Some props.SupervisorStrategy
+        }
+
+    static member internal From(props: Props, receiver: obj) : Props<'Message> =
+        { ActorType = props.Type
+          Receiver = receiver
+          Deploy = Some props.Deploy
+          Dispatcher = if props.Dispatcher = Deploy.NoDispatcherGiven then None else Some props.Dispatcher
+          Mailbox = if props.Mailbox = Deploy.NoMailboxGiven then None else Some props.Mailbox
+          Router =  if props.RouterConfig = Akka.Routing.RouterConfig.NoRouter then None else Some props.RouterConfig
+          SupervisionStrategy = if props.SupervisorStrategy = null then None else Some props.SupervisorStrategy
+        }
+
+    interface Akka.Util.ISurrogated with
+        member this.ToSurrogate _ =
+            let props = this.ToProps false
+            let surrogate: PropsSurrogate<'Message> = { Wrapped = props; ReceiverBytes = exprSerializer.Pickle(this.Receiver) } 
+            surrogate :> Akka.Util.ISurrogate
+
+and PropsSurrogate<'Message> = 
+    { Wrapped: Props; ReceiverBytes: byte array }
+    interface Akka.Util.ISurrogate with
+        member this.FromSurrogate _ = Props<'Message>.From (this.Wrapped, exprSerializer.UnPickle (this.ReceiverBytes)) :> Akka.Util.ISurrogated
+
+/// <summary>
+/// Creates a props describing a way to incarnate actor with behavior described by <paramref name="receive"/> function.
+/// </summary>
+let inline props (receive: Actor<'Message>->Behavior<'Message>) : Props<'Message> = 
+    Props<'Message>.Create<FunActor<'Message>, Actor<'Message>, 'Message>(receive)
+
+/// <summary>
+/// Creates a props describing a way to incarnate actor with behavior described by <paramref name="expr"/> expression.
+/// </summary>
+let inline propse (expr: Expr<(Actor<'Message> -> Behavior<'Message>)>) : Props<'Message> =
+    Props<'Message>.Create<FunActor<'Message>, Actor<'Message>, 'Message>(expr)

--- a/src/Akkling/Spawning.fs
+++ b/src/Akkling/Spawning.fs
@@ -15,19 +15,7 @@ open Microsoft.FSharp.Linq.QuotationEvaluation
 
 [<RequireQualifiedAccess>]
 module Configuration = 
-    /// Parses provided HOCON string into a valid Akka configuration object.
-    let parse = Akka.Configuration.ConfigurationFactory.ParseString
-    
-    /// Returns default Akka for F# configuration.
-    let defaultConfig () = Akka.Configuration.ConfigurationFactory.Default()
-    
-    /// Loads Akka configuration from the project's .config file.
-    let load = Akka.Configuration.ConfigurationFactory.Load
-
-module System = 
-    /// Creates an actor system with remote deployment serialization enabled.
-    let create (name : string) (config : Akka.Configuration.Config) : ActorSystem = 
-        let extConfig = config.WithFallback(Configuration.parse """
+    let internal extendedConfig = (Akka.Configuration.ConfigurationFactory.ParseString """
             akka.actor {
                 serializers {
                     wire = "Akka.Serialization.WireSerializer, Akka.Serialization.Wire"
@@ -37,8 +25,21 @@ module System =
                 }
             }
         """)
+
+    /// Parses provided HOCON string into a valid Akka configuration object.
+    let parse = Akka.Configuration.ConfigurationFactory.ParseString
+    
+    /// Returns default Akka for F# configuration.
+    let defaultConfig () = extendedConfig.WithFallback(Akka.Configuration.ConfigurationFactory.Default())
+    
+    /// Loads Akka configuration from the project's .config file.
+    let load = Akka.Configuration.ConfigurationFactory.Load
+
+module System = 
+    /// Creates an actor system with remote deployment serialization enabled.
+    let create (name : string) (config : Akka.Configuration.Config) : ActorSystem = 
         let _ = Akka.Serialization.WireSerializer           // I don't know why, but without this system cannot instantiate serializer
-        let system = ActorSystem.Create(name, extConfig)
+        let system = ActorSystem.Create(name, config.WithFallback Configuration.extendedConfig)
         let exprSerializer = Akkling.Serialization.ExprSerializer(system :?> ExtendedActorSystem)
         system.Serialization.AddSerializer(exprSerializer)
         system.Serialization.AddSerializationMap(typeof<Expr>, exprSerializer)
@@ -46,87 +47,25 @@ module System =
 
 [<AutoOpen>]
 module Spawn = 
-    type SpawnOption = 
-        | Deploy of Deploy
-        | Router of Akka.Routing.RouterConfig
-        | SupervisorStrategy of SupervisorStrategy
-        | Dispatcher of string
-        | Mailbox of string
-    
-    let rec applySpawnOptions (props : Props) (opt : SpawnOption list) : Props = 
-        match opt with
-        | [] -> props
-        | h :: t -> 
-            let p = 
-                match h with
-                | Deploy d -> props.WithDeploy d
-                | Router r -> props.WithRouter r
-                | SupervisorStrategy s -> props.WithSupervisorStrategy s
-                | Dispatcher d -> props.WithDispatcher d
-                | Mailbox m -> props.WithMailbox m
-            applySpawnOptions p t
-    
+
     /// <summary>
-    /// Spawns an actor using specified actor computation expression, using an Expression AST.
-    /// The actor code can be deployed remotely.
-    /// </summary>
-    /// <param name="actorFactory">Either actor system or parent actor</param>
-    /// <param name="name">Name of spawned child actor</param>
-    /// <param name="expr">F# expression compiled down to receive function used by actor for response for incoming request</param>
-    /// <param name="options">List of options used to configure actor creation</param>
-    let spawne (options : SpawnOption list) (actorFactory : IActorRefFactory) (name : string) 
-        (expr : Expr<Actor<'Message> -> Behavior<'Message>>) : IActorRef<'Message> = 
-        let e = Linq.Expression.ToExpression(fun () -> new FunActor<'Message>(expr))
-        let props = applySpawnOptions (Props.Create e) options
-        typed (actorFactory.ActorOf(props, name)) :> IActorRef<'Message>
-    
-    /// <summary>
-    /// Spawns an actor using specified actor computation expression, with custom spawn option settings.
-    /// The actor can only be used locally. 
+    /// Spawns an actor using specified actor <see cref="Props{Message}"/>.
     /// </summary>
     /// <param name="actorFactory">Either actor system or parent actor</param>
     /// <param name="name">Name of spawned child actor</param>
     /// <param name="f">Used by actor for handling response for incoming request</param>
-    /// <param name="options">List of options used to configure actor creation</param>
-    let spawnOpt (options : SpawnOption list) (actorFactory : IActorRefFactory) (name : string) (f : Actor<'Message> -> Behavior<'Message>) : IActorRef<'Message> = 
-        let e = Linq.Expression.ToExpression(fun () -> new FunActor<'Message>(f))
-        let props = applySpawnOptions (Props.Create e) options
-        typed (actorFactory.ActorOf(props, name)) :> IActorRef<'Message>
-            
+    let spawn (actorFactory : IActorRefFactory) (name : string) (p: Props<'Message>) : IActorRef<'Message> = 
+        typed (actorFactory.ActorOf(p.ToProps(), name)) :> IActorRef<'Message>
+
     /// <summary>
-    /// Spawns an actor using specified actor computation expression.
-    /// The actor can only be used locally. 
+    /// Spawns an anonymous actor with automatically generated name using specified actor <see cref="Props{Message}"/>.
     /// </summary>
     /// <param name="actorFactory">Either actor system or parent actor</param>
     /// <param name="name">Name of spawned child actor</param>
     /// <param name="f">Used by actor for handling response for incoming request</param>
-    let spawn (actorFactory : IActorRefFactory) (name : string) (f : Actor<'Message> -> Behavior<'Message>) : IActorRef<'Message> = 
-        spawnOpt [] actorFactory name f 
-    
-    /// <summary>
-    /// Spawns an actor using specified actor quotation, with custom spawn option settings.
-    /// The actor can only be used locally. 
-    /// </summary>
-    /// <param name="actorFactory">Either actor system or parent actor</param>
-    /// <param name="name">Name of spawned child actor</param>
-    /// <param name="f">Used to create a new instance of the actor</param>
-    /// <param name="options">List of options used to configure actor creation</param>
-    let spawnObjOpt (actorFactory : IActorRefFactory) (name : string) (f : Quotations.Expr<unit -> #ActorBase>) 
-        (options : SpawnOption list) : IActorRef<'Message> = 
-        let e = Linq.Expression.ToExpression<'Actor> f
-        let props = applySpawnOptions (Props.Create e) options
-        typed (actorFactory.ActorOf(props, name)) :> IActorRef<'Message>
-    
-    /// <summary>
-    /// Spawns an actor using specified actor quotation.
-    /// The actor can only be used locally. 
-    /// </summary>
-    /// <param name="actorFactory">Either actor system or parent actor</param>
-    /// <param name="name">Name of spawned child actor</param>
-    /// <param name="f">Used to create a new instance of the actor</param>
-    let spawnObj (actorFactory : IActorRefFactory) (name : string) (f : Quotations.Expr<unit -> #ActorBase>) : IActorRef<'Message> = 
-        spawnObjOpt actorFactory name f []
-    
+    let inline spawnAnonymous (actorFactory : IActorRefFactory) (p: Props<'Message>) : IActorRef<'Message> = 
+        spawn actorFactory null p
+
     /// <summary>
     /// Wraps provided function with actor behavior. 
     /// It will be invoked each time, an actor will receive a message. 


### PR DESCRIPTION
Since existing actor spawning will be hard to cooperate with incoming cluster features (which are based on Akka.NET `Props`), this PR introduces typed version of Props characteristic to F#, which is based on record.
- Props are typed on message type. They are also serializable.
- All `spawn` variants have been removed. Now it's only `spawn` and `spawnAnonymous`. Everything has been moved to props methods: `props`, `propse`, `propsPersist`, `propsPersiste`, `propsView`, `propsViewe`.
- there are no longer `spawnOpt` variants as props can be used as records i.e. `{ props behavior with Deploy = Some(Deploy.Local) }`.

cc #29
