### PR TITLE
helpers for cluster singleton and client

### DIFF
--- a/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
+++ b/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
@@ -61,6 +61,8 @@
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="ClusterExtensions.fs" />
     <Compile Include="ClusterSingleton.fs" />
+    <Compile Include="DistributedPubSub.fs" />
+    <Compile Include="ClusterClient.fs" />
     <Compile Include="ClusterSharding.fs" />
     <None Include="Akkling.Cluster.Sharding.fsproj.paket.template" />
     <None Include="paket.references" />

--- a/src/Akkling.Cluster.Sharding/ClusterClient.fs
+++ b/src/Akkling.Cluster.Sharding/ClusterClient.fs
@@ -1,0 +1,23 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ClusterClient.fs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+//     Copyright (C) 2016 Bartosz Sypytkowski <gttps://github.com/Horusiath>
+// </copyright>
+//-----------------------------------------------------------------------
+
+module Akkling.Cluster.ClusterClient
+
+open Akkling
+open Akka.Actor
+open Akka.Cluster.Tools.Client
+
+/// <summary>
+/// Returns cluster client receptionist, allowing actors to register themselves to be visible outside the cluster.
+/// </summary>
+let receptionist (system: ActorSystem) : ClusterClientReceptionist = ClusterClientReceptionist.Get(system)
+
+/// <summary>
+/// Returns actor reference to cluster client, allowing you to send messages to cluster.
+/// </summary>
+let clusterClient (system: ActorSystem) : IActorRef<obj> = typed <| system.ActorOf(ClusterClient.Props(ClusterClientSettings.Create system))

--- a/src/Akkling.Cluster.Sharding/ClusterExtensions.fs
+++ b/src/Akkling.Cluster.Sharding/ClusterExtensions.fs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="Sharding.fs" company="Akka.NET Project">
+// <copyright file="ClusterExtensions.fs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 //     Copyright (C) 2016 Bartosz Sypytkowski <gttps://github.com/Horusiath>
@@ -18,3 +18,15 @@ open Akkling
 let joinCluster (system: ActorSystem) (addresses: Address seq) : unit =
     let cluster = Cluster.Get system
     cluster.JoinSeedNodes (ImmutableList.CreateRange(addresses))
+
+let (|IMemberEvent|_|) (msg: obj) : ClusterEvent.IMemberEvent option =
+    match msg with
+    | :? ClusterEvent.IMemberEvent as e -> Some e
+    | _ -> None
+
+let (|MemberUp|MemberExited|MemberRemoved|) (msg: ClusterEvent.IMemberEvent): Choice<Member, Member, Member> =
+    match msg with
+    | :? ClusterEvent.MemberUp as up -> Choice1Of3 (up.Member)
+    | :? ClusterEvent.MemberExited as exit -> Choice2Of3 (exit.Member)  
+    | :? ClusterEvent.MemberRemoved as removed -> Choice3Of3 (removed.Member)
+    | _ -> failwith ("unknown cluster event type " + msg.GetType().ToString())

--- a/src/Akkling.Cluster.Sharding/ClusterSingleton.fs
+++ b/src/Akkling.Cluster.Sharding/ClusterSingleton.fs
@@ -1,16 +1,36 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="ClusterSharding.fs" company="Akka.NET Project">
+// <copyright file="ClusterSingleton.fs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
 //     Copyright (C) 2016 Bartosz Sypytkowski <gttps://github.com/Horusiath>
 // </copyright>
 //-----------------------------------------------------------------------
 
-[<AutoOpen>]
-module Akkling.Cluster.Sharding.ClusterSingleton
+module Akkling.Cluster.Singleton
 
 open System
 open Akka.Actor
 open Akka.Cluster
-open Akka.Cluster.Sharding
+open Akka.Cluster.Tools.Singleton
 open Akkling
+
+/// <summary>
+/// Spawns an actor in cluster singleton mode.
+/// </summary>
+/// <param name="stopMessage">Message used to stop an actor</param>
+/// <param name="factory">Actor system used to spawn an actor</param>
+/// <param name="name">Actor singleton name.</param>
+/// <param name="props">Props used to build an actor.</param>
+let spawnSingleton (stopMessage: obj) (system: ActorSystem) (name: string) (props: Props<'Message>) : IActorRef<'Message> =
+    let singletonProps = ClusterSingletonManager.Props(props.ToProps(), stopMessage, ClusterSingletonManagerSettings.Create(system))
+    typed (system.ActorOf(singletonProps, name))
+
+/// <summary>
+/// Spawns an actor working as a proxy to cluster singleton provided by <paramref name="singletonPath"/>.
+/// </summary>
+/// <param name="system">Actor system used to spawn an actor</param>
+/// <param name="name">Actor proxy name</param>
+/// <param name="singletonPath">Relative path to cluster singleton actor manager</param>
+let spawnSingletonProxy (system: ActorSystem) (name: string) (singletonPath: string) : IActorRef<'Message> =
+    let proxyProps = ClusterSingletonProxy.Props(singletonPath, ClusterSingletonProxySettings.Create(system))
+    typed (system.ActorOf(proxyProps, name))

--- a/src/Akkling.Cluster.Sharding/DistributedPubSub.fs
+++ b/src/Akkling.Cluster.Sharding/DistributedPubSub.fs
@@ -1,0 +1,15 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DistributedPubSub.fs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+//     Copyright (C) 2016 Bartosz Sypytkowski <gttps://github.com/Horusiath>
+// </copyright>
+//-----------------------------------------------------------------------
+
+module Akkling.Cluster.DistributedPubSub
+
+open Akkling
+open Akka.Actor
+open Akka.Cluster.Tools.PublishSubscribe
+
+


### PR DESCRIPTION
Changes inside the PR:
- Cluster singleton spawn methods: `spawnSingleton` and `spawnSingletonProxy`.
- Initial cluster client methods.
- Active patterns for easier integration with cluster events.
