### PR TITLE
Move xunit.runner.visualstudio dependency to paket

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -19,6 +19,7 @@ nuget Octokit
 nuget SourceLink 
 nuget xunit.assert = 2.0.0 
 nuget xunit.runner.console 
+nuget xunit.runner.visualstudio
 
 nuget Akka prerelease 
 nuget Akka.Streams prerelease 

--- a/paket.lock
+++ b/paket.lock
@@ -102,6 +102,7 @@ NUGET
     xunit.extensibility.core (2.0)
       xunit.abstractions (2.0)
     xunit.runner.console (2.1)
+    xunit.runner.visualstudio (2.1)
 GITHUB
   remote: fsharp/FAKE
     modules/Octokit/Octokit.fsx (be6e4b2b513b5f2cd64ec689fe7f1f45c39f4e92)

--- a/tests/Akkling.Tests/Akkling.Tests.fsproj
+++ b/tests/Akkling.Tests/Akkling.Tests.fsproj
@@ -118,7 +118,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">

--- a/tests/Akkling.Tests/packages.config
+++ b/tests/Akkling.Tests/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
The project would not build on first run of build.cmd because this package was not restored via paket.

#fixes Horusiath/Akkling#45