### PR TITLE
Reference FSharp.Core via the NuGet package

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -19,6 +19,7 @@ nuget SourceLink
 nuget xunit.assert = 2.0.0 
 nuget xunit.runner.console 
 nuget xunit.runner.visualstudio
+nuget FSharp.Core
 
 nuget Akka >= 1.2
 nuget Akka.Streams >= 1.2

--- a/paket.lock
+++ b/paket.lock
@@ -1,5 +1,5 @@
 REDIRECTS: ON
-FRAMEWORK: NET40, NET45, NET451, NET452
+RESTRICTION: || (== net40) (== net45) (== net451) (== net452)
 NUGET
   remote: https://www.nuget.org/api/v2
     Akka (1.2)
@@ -70,21 +70,21 @@ NUGET
       xunit.core (>= 2.0)
       xunit.extensibility.core (>= 2.0)
     DotNetty.Buffers (0.4.4)
-      DotNetty.Common (>= 0.4.4) - framework: net45, net451, net452
+      DotNetty.Common (>= 0.4.4) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
     DotNetty.Codecs (0.4.4)
-      DotNetty.Buffers (>= 0.4.4) - framework: net45, net451, net452
-      DotNetty.Common (>= 0.4.4) - framework: net45, net451, net452
-      DotNetty.Transport (>= 0.4.4) - framework: net45, net451, net452
+      DotNetty.Buffers (>= 0.4.4) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+      DotNetty.Common (>= 0.4.4) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+      DotNetty.Transport (>= 0.4.4) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
     DotNetty.Common (0.4.4)
-      Microsoft.Extensions.Logging (>= 1.1.1) - framework: net45, net451, net452
+      Microsoft.Extensions.Logging (>= 1.1.1) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
     DotNetty.Handlers (0.4.4)
-      DotNetty.Buffers (>= 0.4.4) - framework: net45, net451, net452
-      DotNetty.Codecs (>= 0.4.4) - framework: net45, net451, net452
-      DotNetty.Common (>= 0.4.4) - framework: net45, net451, net452
-      DotNetty.Transport (>= 0.4.4) - framework: net45, net451, net452
+      DotNetty.Buffers (>= 0.4.4) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+      DotNetty.Codecs (>= 0.4.4) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+      DotNetty.Common (>= 0.4.4) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+      DotNetty.Transport (>= 0.4.4) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
     DotNetty.Transport (0.4.4)
-      DotNetty.Buffers (>= 0.4.4) - framework: net45, net451, net452
-      DotNetty.Common (>= 0.4.4) - framework: net45, net451, net452
+      DotNetty.Buffers (>= 0.4.4) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+      DotNetty.Common (>= 0.4.4) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
     FAKE (4.50)
     FsCheck (2.7)
       FSharp.Core (>= 3.1.2.5)
@@ -107,40 +107,40 @@ NUGET
     Microsoft.Bcl (1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
     Microsoft.Bcl.Build (1.0.21) - import_targets: false
-    Microsoft.Extensions.DependencyInjection.Abstractions (1.1) - framework: net45, net451, net452
-    Microsoft.Extensions.Logging (1.1.1) - framework: net45, net451, net452
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 1.1) - framework: net45, net451, net452
-      Microsoft.Extensions.Logging.Abstractions (>= 1.1.1) - framework: net45, net451, net452
-      NETStandard.Library (>= 1.6.1) - framework: net45, net451, net452
-    Microsoft.Extensions.Logging.Abstractions (1.1.1) - framework: net45, net451, net452
-      NETStandard.Library (>= 1.6.1) - framework: net45, net451, net452
+    Microsoft.Extensions.DependencyInjection.Abstractions (1.1) - restriction: || (== net45) (== net451) (== net452)
+    Microsoft.Extensions.Logging (1.1.1) - restriction: || (== net45) (== net451) (== net452)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 1.1) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+      Microsoft.Extensions.Logging.Abstractions (>= 1.1.1) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+      NETStandard.Library (>= 1.6.1) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+    Microsoft.Extensions.Logging.Abstractions (1.1.1) - restriction: || (== net45) (== net451) (== net452)
+      NETStandard.Library (>= 1.6.1) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
     Microsoft.Net.Http (2.2.29)
       Microsoft.Bcl (>= 1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
-    NETStandard.Library (1.6.1) - framework: net45, net451, net452
-      System.Collections.Concurrent (>= 4.3) - framework: net45, net451, net452
-      System.Diagnostics.Tracing (>= 4.3) - framework: net45, net451, net452
-      System.IO.Compression (>= 4.3) - framework: net45, net451, net452
-      System.Net.Http (>= 4.3) - framework: net45, net451, net452
-      System.Runtime.InteropServices (>= 4.3) - framework: net45, net451, net452
-      System.Runtime.InteropServices.RuntimeInformation (>= 4.3) - framework: net45, net451, net452
-      System.Runtime.Numerics (>= 4.3) - framework: net45, net451, net452
-      System.Threading.Timer (>= 4.3) - framework: net451, net452
+    NETStandard.Library (1.6.1) - restriction: || (== net45) (== net451) (== net452)
+      System.Collections.Concurrent (>= 4.3) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+      System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+      System.IO.Compression (>= 4.3) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+      System.Net.Http (>= 4.3) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+      System.Runtime.InteropServices (>= 4.3) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+      System.Runtime.InteropServices.RuntimeInformation (>= 4.3) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+      System.Runtime.Numerics (>= 4.3) - restriction: || (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452)) (== net45) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
+      System.Threading.Timer (>= 4.3) - restriction: || (&& (== net40) (== net451)) (&& (== net40) (== net452)) (&& (== net45) (== net451)) (&& (== net45) (== net452)) (== net451) (&& (== net451) (== net452)) (== net452)
     Newtonsoft.Json (10.0.2)
     Octokit (0.24)
-      Microsoft.Net.Http  - framework: net40
+      Microsoft.Net.Http  - restriction: || (== net40) (&& (== net40) (== net45)) (&& (== net40) (== net451)) (&& (== net40) (== net452))
     Reactive.Streams (1.0.2)
     SourceLink (1.1)
-    System.Collections.Concurrent (4.3) - framework: net45, net451, net452
+    System.Collections.Concurrent (4.3) - restriction: || (== net45) (== net451) (== net452)
     System.Collections.Immutable (1.3.1)
     System.Data.SQLite.Core (1.0.104)
-    System.Diagnostics.Tracing (4.3) - framework: net45, net451, net452
-    System.IO.Compression (4.3) - framework: net45, net451, net452
-    System.Net.Http (4.3.1) - framework: net45, net451, net452
-    System.Runtime.InteropServices (4.3) - framework: net45, net451, net452
-    System.Runtime.InteropServices.RuntimeInformation (4.3) - framework: net45, net451, net452
-    System.Runtime.Numerics (4.3) - framework: net45, net451, net452
-    System.Threading.Timer (4.3) - framework: net451, net452
+    System.Diagnostics.Tracing (4.3) - restriction: || (== net45) (== net451) (== net452)
+    System.IO.Compression (4.3) - restriction: || (== net45) (== net451) (== net452)
+    System.Net.Http (4.3.1) - restriction: || (== net45) (== net451) (== net452)
+    System.Runtime.InteropServices (4.3) - restriction: || (== net45) (== net451) (== net452)
+    System.Runtime.InteropServices.RuntimeInformation (4.3) - restriction: || (== net45) (== net451) (== net452)
+    System.Runtime.Numerics (4.3) - restriction: || (== net45) (== net451) (== net452)
+    System.Threading.Timer (4.3) - restriction: || (== net451) (== net452)
     xunit (2.0)
       xunit.assert (2.0)
       xunit.core (2.0)

--- a/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
+++ b/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
@@ -69,9 +69,6 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -201,6 +198,17 @@
       <ItemGroup>
         <Reference Include="DotNetty.Transport">
           <HintPath>..\..\packages\DotNetty.Transport\lib\net45\DotNetty.Transport.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\..\packages\FSharp.Core\lib\net40\FSharp.Core.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/Akkling.Cluster.Sharding/paket.references
+++ b/src/Akkling.Cluster.Sharding/paket.references
@@ -4,3 +4,4 @@ Akka.Cluster
 Akka.Cluster.Tools
 Akka.Persistence
 Newtonsoft.Json
+FSharp.Core

--- a/src/Akkling.DistributedData/Akkling.DistributedData.fsproj
+++ b/src/Akkling.DistributedData/Akkling.DistributedData.fsproj
@@ -59,9 +59,6 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -171,6 +168,17 @@
       <ItemGroup>
         <Reference Include="DotNetty.Transport">
           <HintPath>..\..\packages\DotNetty.Transport\lib\net45\DotNetty.Transport.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\..\packages\FSharp.Core\lib\net40\FSharp.Core.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/Akkling.DistributedData/paket.references
+++ b/src/Akkling.DistributedData/paket.references
@@ -1,3 +1,4 @@
 Akka
 Akka.DistributedData
 Akka.Cluster
+FSharp.Core

--- a/src/Akkling.Persistence/Akkling.Persistence.fsproj
+++ b/src/Akkling.Persistence/Akkling.Persistence.fsproj
@@ -62,9 +62,6 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -99,6 +96,17 @@
       <ItemGroup>
         <Reference Include="Akka.Persistence">
           <HintPath>..\..\packages\Akka.Persistence\lib\net45\Akka.Persistence.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\..\packages\FSharp.Core\lib\net40\FSharp.Core.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/Akkling.Persistence/paket.references
+++ b/src/Akkling.Persistence/paket.references
@@ -2,3 +2,4 @@ Akka
 Akka.Persistence
 Newtonsoft.Json
 FSPowerPack.Linq.Community
+FSharp.Core

--- a/src/Akkling.Streams/Akkling.Streams.fsproj
+++ b/src/Akkling.Streams/Akkling.Streams.fsproj
@@ -71,9 +71,6 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -99,6 +96,17 @@
       <ItemGroup>
         <Reference Include="Akka.Streams">
           <HintPath>..\..\packages\Akka.Streams\lib\net45\Akka.Streams.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\..\packages\FSharp.Core\lib\net40\FSharp.Core.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/Akkling.Streams/paket.references
+++ b/src/Akkling.Streams/paket.references
@@ -1,3 +1,4 @@
 Akka
 Akka.Streams
 Reactive.Streams
+FSharp.Core

--- a/src/Akkling.TestKit/paket.references
+++ b/src/Akkling.TestKit/paket.references
@@ -2,3 +2,4 @@
 Akka
 Akka.TestKit.Xunit2
 System.Collections.Immutable
+FSharp.Core

--- a/src/Akkling/Akkling.fsproj
+++ b/src/Akkling/Akkling.fsproj
@@ -83,9 +83,6 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -106,6 +103,17 @@
       <ItemGroup>
         <Reference Include="Akka.Serialization.Hyperion">
           <HintPath>..\..\packages\Akka.Serialization.Hyperion\lib\net45\Akka.Serialization.Hyperion.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\..\packages\FSharp.Core\lib\net40\FSharp.Core.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/Akkling/paket.references
+++ b/src/Akkling/paket.references
@@ -4,3 +4,4 @@ FsPickler
 System.Collections.Immutable
 Akka.Serialization.Hyperion
 FSPowerPack.Linq.Community
+FSharp.Core


### PR DESCRIPTION
1. All FSharp.Core references were not found in Rider, no features worked.
2. It's a best practice to always reference FSharp.Core via the NuGet package.