### PR TITLE
Remove untyped IActorRef inheritance in IActorRef<'Message>

### DIFF
--- a/examples/cluster-nodes-status.fsx
+++ b/examples/cluster-nodes-status.fsx
@@ -80,11 +80,11 @@ let clusterStatus = fun (ctx : Actor<_>) ->
         | LifecycleEvent e ->
             match e with
             | PreStart ->
-                cluster.Subscribe(ctx.Self, ClusterEvent.InitialStateAsEvents,
+                cluster.Subscribe(untyped ctx.Self, ClusterEvent.InitialStateAsEvents,
                     [| typedefof<ClusterEvent.IMemberEvent> |])
                 log.Info (sprintf "Actor subscribed to Cluster status updates: %A" ctx.Self)
             | PostStop ->
-                cluster.Unsubscribe(ctx.Self)
+                cluster.Unsubscribe(untyped ctx.Self)
                 log.Info (sprintf "Actor unsubscribed from Cluster status updates: %A" ctx.Self)
 
             | _ -> return Unhandled

--- a/examples/io.fsx
+++ b/examples/io.fsx
@@ -29,13 +29,13 @@ let handler connection = fun (ctx: Actor<obj>) ->
 
 let endpoint = IPEndPoint(IPAddress.Loopback, 5000)
 let listener = spawn system "listener" <| props(fun m ->
-    IO.Tcp(m) <! TcpMessage.Bind(m.Self, endpoint, 100)
+    IO.Tcp(m) <! TcpMessage.Bind(untyped m.Self, endpoint, 100)
     let rec loop () = actor {
         let! (msg: obj) = m.Receive ()
         match msg with
         | Connected(remote, local) ->
             let conn = m.Sender ()
-            conn <! TcpMessage.Register(spawn m null (props(handler conn)))
+            conn <! TcpMessage.Register(untyped (spawn m null (props(handler conn))))
             return! loop ()
         | _ -> return Unhandled
     }

--- a/src/Akkling.Persistence/PersistentActor.fs
+++ b/src/Akkling.Persistence/PersistentActor.fs
@@ -135,9 +135,9 @@ and TypedPersistentContext<'Message, 'Actor when 'Actor :> FunPersistentActor<'M
         member __.UnstashAll() = actor.Stash.UnstashAll()
         member __.SetReceiveTimeout timeout = context.SetReceiveTimeout(Option.toNullable timeout)
         member __.Schedule (delay : TimeSpan) target message =
-            context.System.Scheduler.ScheduleTellOnceCancelable(delay, target, message, self)
+            context.System.Scheduler.ScheduleTellOnceCancelable(delay, untyped target, message, self)
         member __.ScheduleRepeatedly (delay : TimeSpan) (interval : TimeSpan) target message =
-            context.System.Scheduler.ScheduleTellOnceCancelable(delay, target, message, self)
+            context.System.Scheduler.ScheduleTellOnceCancelable(delay, untyped target, message, self)
         member __.Incarnation() = actor :> ActorBase
         member __.Stop(ref : IActorRef<'T>) = context.Stop(untyped ref)
         member __.Unhandled(msg) =

--- a/src/Akkling.Persistence/PersistentView.fs
+++ b/src/Akkling.Persistence/PersistentView.fs
@@ -71,9 +71,9 @@ and TypedViewContext<'Message, 'Actor when 'Actor :> FunPersistentView<'Message>
         member __.UnstashAll() = actor.Stash.UnstashAll()
         member __.SetReceiveTimeout timeout = context.SetReceiveTimeout(Option.toNullable timeout)
         member __.Schedule (delay : TimeSpan) target message = 
-            context.System.Scheduler.ScheduleTellOnceCancelable(delay, target, message, self)
+            context.System.Scheduler.ScheduleTellOnceCancelable(delay, untyped target, message, self)
         member __.ScheduleRepeatedly (delay : TimeSpan) (interval : TimeSpan) target message = 
-            context.System.Scheduler.ScheduleTellOnceCancelable(delay, target, message, self)
+            context.System.Scheduler.ScheduleTellOnceCancelable(delay, untyped target, message, self)
         member __.Incarnation() = actor :> ActorBase
         member __.Stop(ref : IActorRef<'T>) = context.Stop(untyped ref)
         member __.Unhandled(msg) = 

--- a/src/Akkling.Streams/Sink.fs
+++ b/src/Akkling.Streams/Sink.fs
@@ -82,7 +82,7 @@ module Sink =
     /// will be sent to the destination actor.
     /// When the stream is completed with failure a Status.Failure
     /// message will be sent to the destination actor.
-    let inline toActorRef (completeMsg: 't) (ref: IActorRef<'t>) : Sink<'t, unit> = Sink.ActorRef(ref, completeMsg).MapMaterializedValue(Func<_,_>(Microsoft.FSharp.Core.Operators.ignore))
+    let inline toActorRef (completeMsg: 't) (ref: IActorRef<'t>) : Sink<'t, unit> = Sink.ActorRef(untyped ref, completeMsg).MapMaterializedValue(Func<_,_>(Microsoft.FSharp.Core.Operators.ignore))
 
     /// Sends the elements of the stream to the given actor ref that sends back back-pressure signal.
     /// First element is always initMsg, then stream is waiting for acknowledgement message
@@ -90,7 +90,7 @@ module Sink =
     /// elements. It also requires ackMsg message after each stream element
     /// to make backpressure work.
     let inline toActorRefAck (initMsg: 't) (ackMsg: 't) (completeMsg: 't) (failMsgFn: exn -> 't) (ref: IActorRef<'t>) : Sink<'t, unit> = 
-        Sink.ActorRefWithAck(ref, initMsg, ackMsg, completeMsg, Func<_,_>(failMsgFn >> box)).MapMaterializedValue(Func<_,_>(Microsoft.FSharp.Core.Operators.ignore))
+        Sink.ActorRefWithAck(untyped ref, initMsg, ackMsg, completeMsg, Func<_,_>(failMsgFn >> box)).MapMaterializedValue(Func<_,_>(Microsoft.FSharp.Core.Operators.ignore))
 
     /// Creates a sink that is materialized to an actor ref which points to an Actor
     /// created according to the passed in props. Actor created by the props should

--- a/src/Akkling/ActorRefs.fs
+++ b/src/Akkling/ActorRefs.fs
@@ -45,12 +45,12 @@ let private tryCast<'Result>(t: Task<obj>) : AskResult<'Result> =
 /// </summary>
 [<Interface>]
 type ICanTell<'Message> =
-    //inherit ICanTell
     abstract Tell : 'Message * IActorRef -> unit
     abstract Ask : 'Message * TimeSpan option -> Async<AskResult<'Response>>
 
     abstract member Underlying : ICanTell
 
+/// INTERNAL API.
 [<Interface>]
 type IInternalTypedActorRef =
     abstract member Underlying : IActorRef
@@ -63,7 +63,6 @@ type IInternalTypedActorRef =
 type IActorRef<'Message> =
     inherit IInternalTypedActorRef
     inherit ICanTell<'Message>
-    //inherit IActorRef
 
     inherit IEquatable<IActorRef<'Message>>
     inherit IComparable<IActorRef<'Message>>

--- a/src/Akkling/ActorRefs.fs
+++ b/src/Akkling/ActorRefs.fs
@@ -45,22 +45,38 @@ let private tryCast<'Result>(t: Task<obj>) : AskResult<'Result> =
 /// </summary>
 [<Interface>]
 type ICanTell<'Message> =
-    inherit ICanTell
+    //inherit ICanTell
     abstract Tell : 'Message * IActorRef -> unit
     abstract Ask : 'Message * TimeSpan option -> Async<AskResult<'Response>>
+
+    abstract member Underlying : ICanTell
+
+[<Interface>]
+type IInternalTypedActorRef =
+    abstract member Underlying : IActorRef
+    abstract member MessageType : Type
 
 /// <summary>
 /// Typed version of <see cref="IActorRef"/> interface. Allows to tell/ask using only messages of restricted type.
 /// </summary>
 [<Interface>]
 type IActorRef<'Message> =
+    inherit IInternalTypedActorRef
     inherit ICanTell<'Message>
-    inherit IActorRef
+    //inherit IActorRef
+
+    inherit IEquatable<IActorRef<'Message>>
+    inherit IComparable<IActorRef<'Message>>
+    inherit ISurrogated
+    inherit IComparable
+    
     /// <summary>
     /// Changes the type of handled messages, returning new typed ActorRef.
     /// </summary>
     abstract Retype<'T> : unit -> IActorRef<'T>
     abstract Forward : 'Message -> unit
+
+    abstract member Path : ActorPath
 
 /// <summary>
 /// Wrapper around untyped instance of IActorRef interface.
@@ -79,11 +95,13 @@ type TypedActorRef<'Message>(underlyingRef : IActorRef) =
     override __.GetHashCode () = underlyingRef.GetHashCode ()
     override this.Equals o =
         match o with
-        | :? IActorRef as ref -> (this :> IActorRef).Equals(ref)
+        | :? IInternalTypedActorRef as ref -> underlyingRef.Equals(ref.Underlying)
         | _ -> false
 
-    interface ICanTell with
-        member __.Tell(message : obj, sender : IActorRef) = underlyingRef.Tell(message, sender)
+    interface IInternalTypedActorRef with
+        
+        member __.Underlying = underlyingRef
+        member __.MessageType = typeof<'Message>
 
     interface IActorRef<'Message> with
 
@@ -99,22 +117,19 @@ type TypedActorRef<'Message>(underlyingRef : IActorRef) =
                 .Ask(message, Option.toNullable timeout)
                 .ContinueWith(tryCast<'Response>, TaskContinuationOptions.ExecuteSynchronously)
             |> Async.AwaitTask
+        member __.Underlying = underlyingRef :> ICanTell
         member __.Path = underlyingRef.Path
 
         member __.Equals other =
-            match other with
-            | :? TypedActorRef<'Message> as typed -> underlyingRef.Equals(typed.Underlying)
-            | _ -> underlyingRef.Equals other
+            underlyingRef.Equals(other.Underlying)
 
         member __.CompareTo (other: obj) =
             match other with
-            | :? TypedActorRef<'Message> as typed -> underlyingRef.CompareTo(typed.Underlying)
+            | :? IInternalTypedActorRef as typed -> underlyingRef.CompareTo(typed.Underlying)
             | _ -> underlyingRef.CompareTo(other)
 
-        member __.CompareTo (other: IActorRef) =
-            match other with
-            | :? TypedActorRef<'Message> as typed -> underlyingRef.CompareTo(typed.Underlying)
-            | _ -> underlyingRef.CompareTo(other)
+        member __.CompareTo (other: IActorRef<'Message>) =
+            underlyingRef.CompareTo(other.Underlying)
 
     interface ISurrogated with
         member this.ToSurrogate system =
@@ -132,8 +147,7 @@ and TypedActorRefSurrogate<'Message> =
 /// Returns typed wrapper over provided actor reference.
 /// </summary>
 let inline typed (actorRef : IActorRef) : IActorRef<'Message> =
-    if actorRef :? TypedActorRef<'Message> then actorRef :?> TypedActorRef<'Message> :> IActorRef<'Message>
-    else (TypedActorRef<'Message> actorRef) :> IActorRef<'Message>
+    (TypedActorRef<'Message> actorRef) :> IActorRef<'Message>
 
 /// <summary>
 /// Returns untyped <see cref="IActorRef" /> form of current typed actor.
@@ -203,6 +217,8 @@ type TypedActorSelection<'Message>(selection : ActorSelection) =
                 .ContinueWith(tryCast<'Response>, TaskContinuationOptions.ExecuteSynchronously)
             |> Async.AwaitTask
 
+        member __.Underlying = selection :> ICanTell
+
     interface IComparable with
         member this.CompareTo other =
             match other with
@@ -233,7 +249,7 @@ let inline (<<!) (actorRef : #IActorRef<'Message>) (msg : 'Message) : unit =
 /// Pipes an output of asynchronous expression directly to the recipients mailbox.
 let pipeTo (sender : IActorRef) (recipient : ICanTell<'Message>) (computation : Async<'Message>): unit =
     let success (result : 'Message) : unit = recipient.Tell(result, sender)
-    let failure (err : exn) : unit = recipient.Tell(Status.Failure(err), sender)
+    let failure (err : exn) : unit = recipient.Underlying.Tell(Status.Failure(err), sender)
     Async.StartWithContinuations(computation, success, failure, failure)
 
 /// Pipe operator which sends an output of asynchronous expression directly to the recipients mailbox.

--- a/src/Akkling/Actors.fs
+++ b/src/Akkling/Actors.fs
@@ -137,11 +137,11 @@ and TypedContext<'Message, 'Actor when 'Actor :> ActorBase and 'Actor :> IWithUn
         member __.UnstashAll() = actor.Stash.UnstashAll()
         member __.SetReceiveTimeout timeout = context.SetReceiveTimeout(Option.toNullable timeout)
         member __.Schedule (delay : TimeSpan) target message = 
-            context.System.Scheduler.ScheduleTellOnceCancelable(delay, target, message, self)
+            context.System.Scheduler.ScheduleTellOnceCancelable(delay, untyped target, message, self)
         member __.ScheduleRepeatedly (delay : TimeSpan) (interval : TimeSpan) target message = 
-            context.System.Scheduler.ScheduleTellRepeatedlyCancelable(delay, interval, target, message, self)
+            context.System.Scheduler.ScheduleTellRepeatedlyCancelable(delay, interval, untyped target, message, self)
         member __.Incarnation() = actor :> ActorBase
-        member __.Stop(ref : IActorRef<'T>) = context.Stop(untyped ref)
+        member __.Stop(ref : IActorRef<'T>) = context.Stop(untyped(ref))
         member __.Unhandled(msg) = 
             match box actor with
             | :? FunActor<'Message> as act -> act.InternalUnhandled(msg)

--- a/src/Akkling/IO.fs
+++ b/src/Akkling/IO.fs
@@ -78,7 +78,7 @@ module IO =
     module Udp =
 
         let inline Bind(ref: IActorRef<'t>, localAddress: EndPoint) = 
-            Akka.IO.Udp.Bind(ref, localAddress) :> Udp.Command
+            Akka.IO.Udp.Bind(untyped ref, localAddress) :> Udp.Command
             
         let (|Received|_|) (msg:obj) : ByteString option =
             match msg with

--- a/src/Akkling/Schedulers.fs
+++ b/src/Akkling/Schedulers.fs
@@ -49,7 +49,7 @@ type ITellScheduler with
     /// <param name="message">Message to be sent to the receiver by the scheduler.</param>
     /// <param name="receiver">Message receiver.</param>
     member this.ScheduleTellRepeatedly(after : TimeSpan, every : TimeSpan, receiver : ICanTell<'Message>, message : 'Message) : unit = 
-        this.ScheduleTellRepeatedly(after, every, receiver, message, ActorRefs.NoSender)
+        this.ScheduleTellRepeatedly(after, every, receiver.Underlying, message, ActorRefs.NoSender)
     
     /// <summary>
     /// Schedules a single <paramref name="message"/> send to the provided <paramref name="receiver"/>.
@@ -58,4 +58,4 @@ type ITellScheduler with
     /// <param name="message">Message to be sent to the receiver by the scheduler.</param>
     /// <param name="receiver">Message receiver.</param>
     member this.ScheduleTellOnce(after : TimeSpan, receiver : ICanTell<'Message>, message : 'Message) : unit = 
-        this.ScheduleTellOnce(after, receiver, message, ActorRefs.NoSender)
+        this.ScheduleTellOnce(after, receiver.Underlying, message, ActorRefs.NoSender)

--- a/src/Akkling/Utils.fs
+++ b/src/Akkling/Utils.fs
@@ -17,12 +17,12 @@ module Watchers =
     /// Orders a <paramref name="watcher"/> to monitor an actor targeted by provided <paramref name="subject"/>.
     /// When an actor refered by subject dies, a watcher should receive a <see cref="Terminated"/> message.
     /// </summary>
-    let monitor (watcher : #ICanWatch) (subject : IActorRef) : IActorRef = watcher.Watch subject
+    let monitor (watcher : #ICanWatch) (subject : IActorRef<'Message>) : IActorRef = watcher.Watch (untyped subject)
     
     /// <summary>
     /// Orders a <paramref name="watcher"/> to stop monitoring an actor refered by provided <paramref name="subject"/>.
     /// </summary>
-    let demonitor (watcher : #ICanWatch) (subject : IActorRef) : IActorRef = watcher.Unwatch subject
+    let demonitor (watcher : #ICanWatch) (subject : IActorRef<'Message>) : IActorRef = watcher.Unwatch (untyped subject)
 
 [<AutoOpen>]
 module EventStreaming = 

--- a/src/Akkling/Utils.fs
+++ b/src/Akkling/Utils.fs
@@ -30,13 +30,13 @@ module EventStreaming =
     /// Subscribes an actor reference to target channel of the provided event stream.
     /// </summary>
     let subscribe (ref : IActorRef<'Message>) (eventStream : Akka.Event.EventStream) : bool = 
-        eventStream.Subscribe(ref, typeof<'Message>)
+        eventStream.Subscribe(untyped ref, typeof<'Message>)
     
     /// <summary>
     /// Unubscribes an actor reference from target channel of the provided event stream.
     /// </summary>
     let unsubscribe (ref : IActorRef<'Message>) (eventStream : Akka.Event.EventStream) : bool = 
-        eventStream.Unsubscribe(ref, typeof<'Message>)
+        eventStream.Unsubscribe(untyped ref, typeof<'Message>)
     
     /// <summary>
     /// Publishes an event on the provided event stream. Event channel is resolved from event's type.


### PR DESCRIPTION
This PR implements my proposed changes from #63 and thereby fixes the issues #57 and #59.
The interfaces `IActorRef<'Message>` and `ICanTell<'Message>` no longer inherit the Akka interfaces `IActorRef` and `ICanTell` respectively. 

~~Some examples will break because of this, since where `IActorRef<'Message>` was previously implicitly upcasted to `IActorRef`. At these places an explicit call of `untyped` is now required. I will fix the examples in a seperate PR.~~
I fixed the examples that were broken because of the change.