### PR TITLE
Fix GraphDsl.Builder.To generic parameter

### DIFF
--- a/src/Akkling.Streams/Graph.fs
+++ b/src/Akkling.Streams/Graph.fs
@@ -50,7 +50,7 @@ module Operators =
 
     type GraphDsl.Builder<'mat> with
         member b.From(source: Source<'i,'mat>) = b.From(source :> IGraph<SourceShape<'i>,'mat>)
-        member b.To(sink: Sink<'o,'mat2>) = b.To(sink :> IGraph<SinkShape<'o>,'mat>)
+        member b.To(sink: Sink<'o,'mat2>) = b.To(sink :> IGraph<SinkShape<'o>,'mat2>)
 
     [<Struct>]
     type ForwardFunctor = ForwardFunctor with


### PR DESCRIPTION
This fixes 

![image](https://user-images.githubusercontent.com/873919/34223162-5b6277f4-e5cf-11e7-8178-54436d7ab2f4.png)
