### PR TITLE
Applied remaining akka streams stages

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -957,9 +957,5 @@ NUGET
     xunit.runner.visualstudio (2.4.0-beta.1.build3958)
 GITHUB
   remote: fsharp/FAKE
-<<<<<<< HEAD
     modules/Octokit/Octokit.fsx (96f1594fd50ced6c1aa45d7cf74fb6c067d08ac1)
-=======
-    modules/Octokit/Octokit.fsx (dd92a63bf27cae3f34c0ca142102e37fd4af3d70)
->>>>>>> applied remaining akka streams stages
       Octokit (>= 0.20)

--- a/paket.lock
+++ b/paket.lock
@@ -957,5 +957,9 @@ NUGET
     xunit.runner.visualstudio (2.4.0-beta.1.build3958)
 GITHUB
   remote: fsharp/FAKE
+<<<<<<< HEAD
     modules/Octokit/Octokit.fsx (96f1594fd50ced6c1aa45d7cf74fb6c067d08ac1)
+=======
+    modules/Octokit/Octokit.fsx (dd92a63bf27cae3f34c0ca142102e37fd4af3d70)
+>>>>>>> applied remaining akka streams stages
       Octokit (>= 0.20)

--- a/src/Akkling.Streams/Akkling.Streams.fsproj
+++ b/src/Akkling.Streams/Akkling.Streams.fsproj
@@ -7,6 +7,7 @@
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Framing.fs" />
     <Compile Include="Prolog.fs" />
+    <Compile Include="Stages.fs" />
     <Compile Include="Flow.fs" />
     <Compile Include="Sink.fs" />
     <Compile Include="SubFlow.fs" />

--- a/src/Akkling.Streams/Flow.fs
+++ b/src/Akkling.Streams/Flow.fs
@@ -15,6 +15,7 @@ open Akka.Streams.Dsl
 
 [<RequireQualifiedAccess>]
 module Flow =
+    open Stages
 
     /// Creates a new empty flow.
     let empty<'t, 'mat> : Flow<'t, 't, 'mat> = Flow.Create<'t, 'mat>()
@@ -31,6 +32,12 @@ module Flow =
     let inline recoverWithRetries (attempts: int) (fn: exn -> #IGraph<SourceShape<'out>, 'mat>) (flow) : Flow<'inp, 'out, 'mat> =
         FlowOperations.RecoverWithRetries(flow, Func<exn, Akka.Streams.IGraph<SourceShape<_>, _>>(fun ex -> upcast fn ex), attempts)
         
+    /// While similar to recover, this stage can be used to transform an error signal to a different one without logging
+    /// it as an error in the process. So in that sense it is NOT exactly equivalent to Recover(e => throw e2) since Recover
+    /// would log the e2 error. 
+    let inline mapError (fn: exn -> #exn) (flow) : Flow<'inp,'out,'mat> =
+        FlowOperations.SelectError(flow, Func<exn, exn>(fun e -> upcast fn e))
+
     /// Transform this stream by applying the given function to each of the elements
     /// as they pass through this processing step.
     let inline map (fn: 'u -> 'w) (flow: Flow<'t, 'u, 'mat>) : Flow<'t, 'w, 'mat> =
@@ -137,6 +144,12 @@ module Flow =
     /// If the function throws an exception and the supervision decision is
     /// restart current value starts at zero again the stream will continue.
     let inline scan (folder: 'w -> 'u -> 'w) (state: 'w) (flow) : Flow<'t, 'w, 'mat> = FlowOperations.Scan(flow, state, Func<_,_,_>(folder))
+
+    /// Similar to scan but with a asynchronous function, emits its current value which 
+    /// starts at zero and then applies the current and next value to the given function
+    /// emitting an Async that resolves to the next current value.
+    let inline asyncScan (folder: 'state -> 'out -> Async<'state>) (zero: 'state) (flow: Flow<'inp,'out,'mat>) : Flow<'inp,'state,'mat> =
+        FlowOperations.ScanAsync(flow, zero, Func<_,_,_>(fun s e -> folder s e |> Async.StartAsTask))
 
     /// Similar to scan but only emits its result when the upstream completes,
     /// after which it also completes. Applies the given function towards its current and next value,
@@ -264,10 +277,13 @@ module Flow =
     /// there is no space available
     let inline buffer (strategy: OverflowStrategy) (n: int) (flow) : Flow<'t, 'u, 'mat> = FlowOperations.Buffer(flow, n, strategy)
             
-    /// Takes up to <paramref name="n"/> elements from the stream and returns a pair containing a strict sequence of the taken element
-    /// and a stream representing the remaining elements. If <paramref name="n"/> is zero or negative, then this will return a pair
+    /// Takes up to n elements from the stream and returns a pair containing a strict sequence of the taken element
+    /// and a stream representing the remaining elements. If `n` is zero or negative, then this will return a pair
     /// of an empty collection and a stream containing the whole upstream unchanged.
-    //let inline prefixAndTail n flow = FlowOperations.PrefixAndTail(flow, n)
+    let inline prefixAndTail (n: int) (flow) : Flow<'inp,'out list * Source<'out, unit>, 'mat> = 
+        FlowOperations.PrefixAndTail(flow, n).Select(Func<_,_>(fun (imm, source) -> 
+            let s = source.MapMaterializedValue(Func<_,_>(ignore))
+            (List.ofSeq imm), s))
 
     /// This operation demultiplexes the incoming stream into separate output
     /// streams, one for each element key. The key is computed for each element
@@ -316,6 +332,11 @@ module Flow =
     /// substreams are being consumed at any given time.
     let inline collectMerge (breadth: int) (flatten: 'u -> #IGraph<SourceShape<'w>, 'mat>) (flow) : Flow<'t, 'w, 'mat> =
         FlowOperations.MergeMany(flow, breadth, Func<_,_>(fun x -> upcast flatten x))
+
+    /// Combine the elements of current flow into a stream of tuples consisting
+    /// of all elements paired with their index. Indices start at 0.
+    let inline zipi (flow) : Flow<'inp, 'out * int64, 'mat> =
+        FlowOperations.ZipWithIndex(flow)
 
     /// If the first element has not passed through this stage before the provided timeout, the stream is failed
     /// with a TimeoutException
@@ -569,3 +590,8 @@ module Flow =
         |> map (fun (x, s) ->
             if x.IsSuccess then Ok x.Value, s
             else Result.Error x.Exception, s) 
+    
+    /// Filters our consecutive duplicated elements from the stream (uniqueness is recognized 
+    /// by provided function).
+    let inline deduplicate (eq: 'out -> 'out -> bool) (flow: Flow<'inp,'out,'mat>) : Flow<'inp, 'out, 'mat> =
+        flow.Via(Deduplicate(eq))

--- a/src/Akkling.Streams/Flow.fs
+++ b/src/Akkling.Streams/Flow.fs
@@ -15,6 +15,7 @@ open Akka.Streams.Dsl
 
 [<RequireQualifiedAccess>]
 module Flow =
+    open Reactive.Streams
     open Stages
 
     /// Creates a new empty flow.
@@ -590,6 +591,14 @@ module Flow =
         |> map (fun (x, s) ->
             if x.IsSuccess then Ok x.Value, s
             else Result.Error x.Exception, s) 
+    
+    /// Joins a provided flow with given sink, returning a new sink in the result.
+    let inline toSink (sink: #IGraph<SinkShape<'out>,'mat2>) (flow: Flow<'inp,'out,'mat>) : Sink<'inp,'mat> = 
+        flow.To(sink)
+    
+    /// Joins a provided flow with given sink, returning a new sink in the result.
+    let inline toProcessor (flow: Flow<'inp,'out,'mat>) : IRunnableGraph<IProcessor<'inp,'out>> = 
+        flow.ToProcessor()
     
     /// Filters our consecutive duplicated elements from the stream (uniqueness is recognized 
     /// by provided function).

--- a/src/Akkling.Streams/Source.fs
+++ b/src/Akkling.Streams/Source.fs
@@ -703,6 +703,15 @@ module Source =
     /// dynamic set of producers
     let inline mergeHub (perProducerBufferSize) = MergeHub.Source(perProducerBufferSize)
     
+    /// Combines current source with provided sink, resulting in a completed runnable graph.
+    let inline toSink (sink: #IGraph<SinkShape<'t>,'mat2>) (source: Source<'t,'mat>) : IRunnableGraph<'mat> = 
+        source.To(sink)
+        
+    let zipn (sources: #(Source<'t, unit> seq)) : Source<'t seq, unit> =
+        Source.ZipN(sources |> Seq.map (mapMaterializedValue (fun () -> NotUsed.Instance)))
+        |> map (fun list -> list :> _ seq)
+        |> mapMaterializedValue ignore 
+    
     /// Filters our consecutive duplicated elements from the stream (uniqueness is recognized 
     /// by provided function).
     let inline deduplicate (eq: 'a -> 'a -> bool) (source: Source<'a,'mat>) : Source<'a, 'mat> =

--- a/src/Akkling.Streams/Source.fs
+++ b/src/Akkling.Streams/Source.fs
@@ -21,6 +21,7 @@ open Reactive.Streams
 [<RequireQualifiedAccess>]
 module Source =
     open Akka
+    open Stages
 
     /// Creates a source from an stream created by the given function.
     let inline ofStream (streamFn: unit -> Stream) : Source<ByteString, Async<IOResult>> =
@@ -164,6 +165,12 @@ module Source =
     /// Source may be materialized.
     let inline recoverWithRetries (attempts: int) (fn: exn -> #IGraph<SourceShape<'out>, 'mat>) (source) : Source<'out, 'mat> =
         SourceOperations.RecoverWithRetries(source, Func<exn, Akka.Streams.IGraph<SourceShape<_>, _>>(fun ex -> upcast fn ex), attempts)
+    
+    /// While similar to recover, this stage can be used to transform an error signal to a different one without logging
+    /// it as an error in the process. So in that sense it is NOT exactly equivalent to Recover(e => throw e2) since Recover
+    /// would log the e2 error. 
+    let inline mapError (fn: exn -> #exn) (source) : Source<'out,'mat> =
+        SourceOperations.SelectError(source, Func<exn, exn>(fun e -> upcast fn e))
 
     /// Transform this stream by applying the given function to each of the elements
     /// as they pass through this processing step.
@@ -270,6 +277,12 @@ module Source =
     /// restart current value starts at zero again the stream will continue.
     let inline scan (folder: 'state -> 't -> 'state) (zero: 'state) (source) : Source<'state, 'mat> =
         SourceOperations.Scan(source, zero, Func<_,_,_>(folder))
+
+    /// Similar to scan but with a asynchronous function, emits its current value which 
+    /// starts at zero and then applies the current and next value to the given function
+    /// emitting an Async that resolves to the next current value.
+    let inline asyncScan (folder: 'state -> 't -> Async<'state>) (zero: 'state) (source) : Source<'state,'mat> =
+        SourceOperations.ScanAsync(source, zero, Func<_,_,_>(fun s e -> folder s e |> Async.StartAsTask))
 
     /// Similar to scan but only emits its result when the upstream completes,
     /// after which it also completes. Applies the given function towards its current and next value,
@@ -412,9 +425,12 @@ module Source =
         SourceOperations.Buffer(source, n, strategy)
 
     /// Takes up to n elements from the stream and returns a pair containing a strict sequence of the taken element
-    /// and a stream representing the remaining elements. If <paramref name="n"/> is zero or negative, then this will return a pair
+    /// and a stream representing the remaining elements. If `n` is zero or negative, then this will return a pair
     /// of an empty collection and a stream containing the whole upstream unchanged.
-    //let inline prefixAndTail n flow = SourceOperations.PrefixAndTail(flow, n)
+    let inline prefixAndTail (n: int) (source) : Source<'out list * Source<'out, unit>, 'mat> = 
+        SourceOperations.PrefixAndTail(source, n).Select(Func<_,_>(fun (imm, source) -> 
+            let s = source.MapMaterializedValue(Func<_,_>(ignore))
+            (List.ofSeq imm), s))
 
     /// This operation demultiplexes the incoming stream into separate output
     /// streams, one for each element key. The key is computed for each element
@@ -463,6 +479,11 @@ module Source =
     /// substreams are being consumed at any given time.
     let inline collectMerge (breadth: int) (flatten: 'u -> #IGraph<SourceShape<'t>, 'mat>) (source) : Source<'t, 'mat> =
         SourceOperations.MergeMany(source, breadth, Func<_,_>(fun x -> upcast flatten x))
+
+    /// Combine the elements of current flow into a stream of tuples consisting
+    /// of all elements paired with their index. Indices start at 0.
+    let inline zipi (source) : Source<'out * int64, 'mat> =
+        SourceOperations.ZipWithIndex(source)
 
     /// If the first element has not passed through this stage before the provided timeout, the stream is failed
     /// with a TimeoutException
@@ -681,3 +702,8 @@ module Source =
     /// A MergeHub is a special streaming hub that is able to collect streamed elements from a 
     /// dynamic set of producers
     let inline mergeHub (perProducerBufferSize) = MergeHub.Source(perProducerBufferSize)
+    
+    /// Filters our consecutive duplicated elements from the stream (uniqueness is recognized 
+    /// by provided function).
+    let inline deduplicate (eq: 'a -> 'a -> bool) (source: Source<'a,'mat>) : Source<'a, 'mat> =
+        source.Via(Deduplicate<'a>(eq))

--- a/src/Akkling.Streams/Stages.fs
+++ b/src/Akkling.Streams/Stages.fs
@@ -8,8 +8,10 @@
 
 module Akkling.Streams.Stages
 
+open Akka.Actor
 open Akka.Streams
 open Akka.Streams.Stage
+open Akkling
 
 [<Sealed>]
 type StageLogic(shape: Shape, init) as this =
@@ -32,6 +34,8 @@ type StageLogic(shape: Shape, init) as this =
     member this.Complete(outlet: Outlet<'a>) = base.Complete(outlet)
     member this.Fail(outlet: Outlet<'a>, error: #exn) = base.Push(outlet, error)
     member this.GetAsyncCallback(handler: 'a -> unit) = base.GetAsyncCallback(System.Action<'a>(handler))
+    member this.StageActorRef<'b>(receive: IActorRef<'b> -> obj -> unit) = 
+        base.GetStageActorRef(StageActorRef.Receive(fun (aref, msg) -> receive (typed aref) msg))
     
 let inline graphStagelogic (shape: #Shape) (init: StageLogic -> unit): GraphStageLogic = upcast StageLogic(shape, init)
 

--- a/src/Akkling.Streams/Stages.fs
+++ b/src/Akkling.Streams/Stages.fs
@@ -1,0 +1,63 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Tcp.fs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+//     Copyright (C) 2015 Bartosz Sypytkowski <gttps://github.com/Horusiath>
+// </copyright>
+//-----------------------------------------------------------------------
+
+module Akkling.Streams.Stages
+
+open Akka.Streams
+open Akka.Streams.Stage
+
+[<Sealed>]
+type StageLogic(shape: Shape, init) as this =
+    inherit GraphStageLogic(shape)
+    do 
+        init(this)
+    member this.Handler(inlet: Inlet<'a>, handler: #IInHandler) = this.SetHandler(inlet, handler)
+    member this.Handler(inlet: Outlet<'a>, handler: #IOutHandler) = this.SetHandler(inlet, handler)
+    member this.Pull(inlet) = base.Pull(inlet)
+    member this.TryPull(inlet) = base.TryPull(inlet)
+    member this.Cancel(inlet) = base.Cancel(inlet)
+    member this.Grab(inlet) = base.Grab(inlet)
+    member this.HasBeenPulled(inlet) = base.HasBeenPulled(inlet)
+    member this.IsAvailable(inlet: Inlet<'a>) = base.IsAvailable(inlet)
+    member this.IsAvailable(outlet: Outlet<'a>) = base.IsAvailable(outlet)
+    member this.IsClosed(inlet: Inlet<'a>) = base.IsClosed(inlet)
+    member this.IsClosed(outlet: Outlet<'a>) = base.IsClosed(outlet)
+    member this.Push(outlet: Outlet<'a>, elem: 'a) = base.Push(outlet, elem)
+    member this.SetKeepGoing(enabled) = base.SetKeepGoing(enabled)
+    member this.Complete(outlet: Outlet<'a>) = base.Complete(outlet)
+    member this.Fail(outlet: Outlet<'a>, error: #exn) = base.Push(outlet, error)
+    member this.GetAsyncCallback(handler: 'a -> unit) = base.GetAsyncCallback(System.Action<'a>(handler))
+    
+let inline graphStagelogic (shape: #Shape) (init: StageLogic -> unit): GraphStageLogic = upcast StageLogic(shape, init)
+
+[<Sealed>]
+type Deduplicate<'a>(eq: 'a -> 'a -> bool) =
+    inherit GraphStage<FlowShape<'a, 'a>>()
+    
+    let mutable last: Option<'a> = None
+    let inlet = Inlet<'a>("deduplicate.in")
+    let outlet = Outlet<'a>("deduplicate.out")
+    
+    override this.Shape = FlowShape(inlet, outlet)
+    override this.CreateLogic attrs = 
+        graphStagelogic this.Shape (fun logic -> 
+            logic.Handler(inlet, { new InHandler() with
+                override x.OnPush() = 
+                    let next = logic.Grab(inlet)
+                    match last with
+                    | Some (l) when eq l next ->
+                        logic.Pull(inlet)
+                    | _ -> 
+                        logic.Push(outlet, next)
+                        last <- Some next
+            })
+            
+            logic.Handler(outlet, { new OutHandler() with
+                override x.OnPull() = logic.Pull(inlet)
+            })
+        )

--- a/tests/Akkling.Tests/Akkling.Tests.fsproj
+++ b/tests/Akkling.Tests/Akkling.Tests.fsproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\src\Akkling.Streams\Akkling.Streams.fsproj" />
     <ProjectReference Include="..\..\src\Akkling.TestKit\Akkling.TestKit.fsproj" />
     <ProjectReference Include="..\..\src\Akkling\Akkling.fsproj" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/tests/Akkling.Tests/StreamsApi.fs
+++ b/tests/Akkling.Tests/StreamsApi.fs
@@ -17,6 +17,7 @@ open System
 open Xunit
 open Akka.Streams.Dsl
 open Akka.Streams
+//open Akka.Streams.TestKit
 
 let config = Configuration.parse "akka.logLevel = DEBUG"
 
@@ -80,3 +81,19 @@ let ``Graph DSL operators should work`` () = test config <| fun tck ->
         |> Async.RunSynchronously
 
     max |> equals 3
+    
+//[<Fact>]
+//let ``A deduplicate must remove consecutive duplicates`` () = test config <| fun tck ->
+//    use mat = tck.Sys.Materializer()
+//    let probe = tck.CreateManualSubscriberProbe<int>()
+//    Source.ofList [1; 1; 1; 2; 2; 1; 1; 3]
+//    |> Source.deduplicate (=)
+//    |> Source.runWith mat (Sink.ofSubscriber probe)
+//
+//    let sub = probe.ExpectSubscription()
+//    sub.request 1000
+//    probe.ExpectNext 1
+//    probe.ExpectNext 2
+//    probe.ExpectNext 1
+//    probe.ExpectNext 3  
+//    probe.ExpectComplete()

--- a/tests/Akkling.Tests/paket.references
+++ b/tests/Akkling.Tests/paket.references
@@ -10,3 +10,5 @@ Microsoft.NET.Test.Sdk
 Akka.Streams
 Microsoft.Extensions.Logging.Abstractions
 Microsoft.Extensions.Logging
+xunit.runner.visualstudio
+Akka.Streams.TestKit


### PR DESCRIPTION
1. Applied remaining stages from Akka.Streams to Akkling.Streams sources, flows and sub-flows:
  - `mapError`
  - `asyncScan`
  - `prefixAndTail`
2. Added adapters to work with custom graph stages. This has been tested on new (unique to Akkling at the moment) operator - `deduplicate`.