### PR TITLE
Add Flow.retrySimple

### DIFF
--- a/src/Akkling.Streams/Akkling.Streams.fsproj
+++ b/src/Akkling.Streams/Akkling.Streams.fsproj
@@ -22,11 +22,11 @@
     <Compile Include="Framing.fs" />
     <Compile Include="Prolog.fs" />
     <Compile Include="Stages.fs" />
-    <Compile Include="Flow.fs" />
     <Compile Include="Sink.fs" />
     <Compile Include="SubFlow.fs" />
     <Compile Include="BidiFlow.fs" />
     <Compile Include="Graph.fs" />
+    <Compile Include="Flow.fs" />
     <Compile Include="KillSwitch.fs" />
     <Compile Include="Source.fs" />
     <Compile Include="Tcp.fs" />


### PR DESCRIPTION
`Flow.retry` is too cumbersome to use, as it requires passing input elements by hand. This new combinator is simpler.  