### PR TITLE
Add Hocon CE

### DIFF
--- a/Akkling.sln
+++ b/Akkling.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30611.23
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{63297B98-5CED-492C-A5B7-A5B4F73CF142}"
 	ProjectSection(SolutionItems) = preProject
@@ -47,7 +47,9 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Akkling.Cluster.Sharding", 
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Akkling.Tests", "tests\Akkling.Tests\Akkling.Tests.fsproj", "{574F1D50-44F6-453C-B36E-F9067EF5A938}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Akkling.Streams.TestKit", "src\Akkling.Streams.TestKit\Akkling.Streams.TestKit.fsproj", "{5FCF0FB2-3C53-4CC5-8383-89888422D40C}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Akkling.Streams.TestKit", "src\Akkling.Streams.TestKit\Akkling.Streams.TestKit.fsproj", "{5FCF0FB2-3C53-4CC5-8383-89888422D40C}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Akkling.Hocon", "src\Akkling.Hocon\Akkling.Hocon.fsproj", "{4E04FB08-075D-4E83-8644-B0A5382E78EF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -87,6 +89,10 @@ Global
 		{5FCF0FB2-3C53-4CC5-8383-89888422D40C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5FCF0FB2-3C53-4CC5-8383-89888422D40C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5FCF0FB2-3C53-4CC5-8383-89888422D40C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E04FB08-075D-4E83-8644-B0A5382E78EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E04FB08-075D-4E83-8644-B0A5382E78EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E04FB08-075D-4E83-8644-B0A5382E78EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E04FB08-075D-4E83-8644-B0A5382E78EF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Akkling.Hocon/Actor.DefaultMailbox.fs
+++ b/src/Akkling.Hocon/Actor.DefaultMailbox.fs
@@ -1,0 +1,84 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module DefaultMailbox =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type DefaultMailboxBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()        
+
+        /// FQCN of the MailboxType. The Class of the FQCN must have a public
+        /// constructor with
+        /// (akka.actor.ActorSystem.Settings, com.typesafe.config.Config) parameters.
+        [<CustomOperation("mailbox_type");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MailboxType (state: string list, x: string) =
+            quotedField "mailbox-type" x::state
+        /// FQCN of the MailboxType. The Class of the FQCN must have a public
+        /// constructor with
+        /// (akka.actor.ActorSystem.Settings, com.typesafe.config.Config) parameters.
+        member this.mailbox_type value =
+            this.MailboxType([], value)
+            |> this.Run
+            
+        /// If the mailbox is bounded then it uses this setting to determine its
+        /// capacity. The provided value must be positive.
+        ///
+        /// NOTICE:
+        /// Up to version 2.1 the mailbox type was determined based on this setting;
+        /// this is no longer the case, the type must explicitly be a bounded mailbox.
+        [<CustomOperation("mailbox_capacity");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MailboxCapacity (state: string list, value: int) =
+            positiveField "mailbox-capacity" value::state
+        /// If the mailbox is bounded then it uses this setting to determine its
+        /// capacity. The provided value must be positive.
+        ///
+        /// NOTICE:
+        /// Up to version 2.1 the mailbox type was determined based on this setting;
+        /// this is no longer the case, the type must explicitly be a bounded mailbox.
+        member this.mailbox_capacity value =
+            this.MailboxCapacity([], value)
+            |> this.Run
+            
+        /// If the mailbox is bounded then this is the timeout for enqueueing
+        /// in case the mailbox is full. Negative values signify infinite
+        /// timeout, which should be avoided as it bears the risk of dead-lock.
+        [<CustomOperation("mailbox_push_timeout_time");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.MailboxPushTimeoutTime (state: string list, value: 'Duration) =
+            durationField "mailbox-push-timeout-time" value::state
+        /// If the mailbox is bounded then this is the timeout for enqueueing
+        /// in case the mailbox is full. Negative values signify infinite
+        /// timeout, which should be avoided as it bears the risk of dead-lock.
+        member inline this.mailbox_push_timeout_time (value: 'Duration) =
+            this.MailboxPushTimeoutTime([], value)
+            |> this.Run
+            
+        /// For Actor with Stash: The default capacity of the stash.
+        /// If negative (or zero) then an unbounded stash is used (default)
+        /// If positive then a bounded stash is used and the capacity is set using
+        /// the property
+        [<CustomOperation("stash_capacity");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.StashCapacity (state: string list, value: int) =
+            numField "stash-capacity" value::state
+        /// For Actor with Stash: The default capacity of the stash.
+        /// If negative (or zero) then an unbounded stash is used (default)
+        /// If positive then a bounded stash is used and the capacity is set using
+        /// the property
+        member this.stash_capacity value =
+            this.StashCapacity([], value)
+            |> this.Run
+
+    let default_mailbox = 
+        { new DefaultMailboxBuilder<Akka.Actor.Field>() with
+            member _.Run (state: string list) =
+                objExpr "default-mailbox" 3 state
+                |> Akka.Actor.Field }
+
+    let custom_mailbox (name: string) = 
+        { new DefaultMailboxBuilder<Akka.Actor.Field>() with
+            member _.Run (state: string list) =
+                objExpr name 3 state
+                |> Akka.Actor.Field }
+    

--- a/src/Akkling.Hocon/Actor.Deployment.fs
+++ b/src/Akkling.Hocon/Actor.Deployment.fs
@@ -1,0 +1,401 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Deployment =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type ResizerBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        [<CustomOperation("enabled");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Enabled (state: string list, value: bool) = 
+            switchField "enabled" value::state
+        member this.enabled value =
+            this.Enabled([], value)
+            |> this.Run
+            
+        /// The fewest number of routees the router should ever have.
+        [<CustomOperation("lower_bound");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.LowerBound (state: string list, value: int) =
+            positiveField "lower-bound" value::state
+        /// The fewest number of routees the router should ever have.
+        member this.lower_bound value =
+            this.LowerBound([], value)
+            |> this.Run
+            
+        /// The most number of routees the router should ever have.
+        /// Must be greater than or equal to lower-bound.
+        [<CustomOperation("upper_bound");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.UpperBound (state: string list, value: int) =
+            positiveField "upper-bound" value::state
+        /// The most number of routees the router should ever have.
+        /// Must be greater than or equal to lower-bound.
+        member this.upper_bound value =
+            this.UpperBound([], value)
+            |> this.Run
+            
+        /// Threshold used to evaluate if a routee is considered to be busy
+        /// (under pressure). 
+        ///
+        /// Implementation depends on this value (default is 1).
+        ///
+        /// 0:   number of routees currently processing a message.
+        ///
+        /// 1:   number of routees currently processing a message has
+        ///      some messages in mailbox.
+        ///
+        /// > 1: number of routees with at least the configured pressure-threshold
+        ///      messages in their mailbox. Note that estimating mailbox size of
+        ///      default UnboundedMailbox is O(N) operation.
+        [<CustomOperation("pressure_threshold");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.PressureThreshold (state: string list, value: int) =
+            positiveField "pressure-threshold" value::state
+        /// Threshold used to evaluate if a routee is considered to be busy
+        /// (under pressure). 
+        ///
+        /// Implementation depends on this value (default is 1).
+        ///
+        /// 0:   number of routees currently processing a message.
+        ///
+        /// 1:   number of routees currently processing a message has
+        ///      some messages in mailbox.
+        ///
+        /// > 1: number of routees with at least the configured pressure-threshold
+        ///      messages in their mailbox. Note that estimating mailbox size of
+        ///      default UnboundedMailbox is O(N) operation.
+        member this.pressure_threshold value =
+            this.PressureThreshold([], value)
+            |> this.Run
+            
+        /// Percentage to increase capacity whenever all routees are busy.
+        /// For example, 0.2 would increase 20% (rounded up), i.e. if current
+        /// capacity is 6 it will request an increase of 2 more routees.
+        [<CustomOperation("rampup_rate");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.RampupRate (state: string list, value) =
+            positiveFieldf "rampup-rate" value::state
+        /// Percentage to increase capacity whenever all routees are busy.
+        /// For example, 0.2 would increase 20% (rounded up), i.e. if current
+        /// capacity is 6 it will request an increase of 2 more routees.
+        member inline this.rampup_rate value =
+            this.RampupRate([], value)
+            |> this.Run
+             
+        /// Minimum fraction of busy routees before backing off.
+        /// For example, if this is 0.3, then we'll remove some routees only when
+        /// less than 30% of routees are busy, i.e. if current capacity is 10 and
+        /// 3 are busy then the capacity is unchanged, but if 2 or less are busy
+        /// the capacity is decreased.
+        /// Use 0.0 or negative to avoid removal of routees.
+        [<CustomOperation("backoff_threshold");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.BackoffThreshold (state: string list, value) =
+            numFieldf "backoff-threshold" value::state
+        /// Minimum fraction of busy routees before backing off.
+        /// For example, if this is 0.3, then we'll remove some routees only when
+        /// less than 30% of routees are busy, i.e. if current capacity is 10 and
+        /// 3 are busy then the capacity is unchanged, but if 2 or less are busy
+        /// the capacity is decreased.
+        /// Use 0.0 or negative to avoid removal of routees.
+        member inline this.backoff_threshold value =
+            this.BackoffThreshold([], value)
+            |> this.Run
+            
+        /// Percentage to increase capacity whenever all routees are busy.
+        /// For example, 0.2 would increase 20% (rounded up), i.e. if current
+        /// capacity is 6 it will request an increase of 2 more routees.
+        [<CustomOperation("backoff_rate");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.BackoffRate (state: string list, value) =
+            positiveFieldf "backoff-rate" value::state
+        /// Percentage to increase capacity whenever all routees are busy.
+        /// For example, 0.2 would increase 20% (rounded up), i.e. if current
+        /// capacity is 6 it will request an increase of 2 more routees.
+        member inline this.backoff_rate value =
+            this.BackoffRate([], value)
+            |> this.Run
+             
+        /// Number of messages between resize operation.
+        /// Use 1 to resize before each message.
+        [<CustomOperation("messages_per_resize");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MessagesPerResize (state: string list, value: int) =
+            positiveField "messages-per-resize" value::state
+        /// Number of messages between resize operation.
+        /// Use 1 to resize before each message.
+        member this.messages_per_resize value =
+            this.MessagesPerResize([], value)
+            |> this.Run
+            
+    /// Routers with dynamically resizable number of routees; this feature is
+    /// enabled by including (parts of) this section in the deployment
+    let resizer = 
+        { new ResizerBuilder<Akka.Actor.DeploymentDefault.Field>() with
+            member _.Run (state: string list) =
+                objExpr "resizer" 5 state
+                |> Akka.Actor.DeploymentDefault.Field }
+    
+    [<AbstractClass>]
+    type RouteesBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        /// Alternatively to giving nr-of-instances you can specify the full
+        /// paths of those actors which should be routed to. This setting takes
+        /// precedence over nr-of-instances
+        [<CustomOperation("paths");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Paths (state: string list, value: string list) =
+            quotedListField "paths" value::state
+        /// Alternatively to giving nr-of-instances you can specify the full
+        /// paths of those actors which should be routed to. This setting takes
+        /// precedence over nr-of-instances
+        member this.paths value =
+            this.Paths([], value)
+            |> this.Run
+
+    let routees = 
+        { new RouteesBuilder<Akka.Actor.DeploymentDefault.Field>() with
+            member _.Run (state: string list) =
+                objExpr "routees" 5 state
+                |> Akka.Actor.DeploymentDefault.Field }
+
+    [<AbstractClass>]
+    type DeployeeBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string, indent: int) =
+        inherit BaseBuilder<'T>()
+
+        let pathObjExpr = pathObjExpr mkField path indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Actor.DeploymentDefault.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Shared.Field<Akka.Shared.Cluster.Field>) = [(x 4).ToString()]
+            
+        /// The id of the dispatcher to use for this actor.
+        /// If undefined or empty the dispatcher specified in code
+        /// (Props.withDispatcher) is used, or default-dispatcher if not
+        /// specified at all.
+        [<CustomOperation("dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Dispatcher (state: string list, value: string) =
+            quotedField "dispatcher" value::state
+        /// The id of the dispatcher to use for this actor.
+        /// If undefined or empty the dispatcher specified in code
+        /// (Props.withDispatcher) is used, or default-dispatcher if not
+        /// specified at all.
+        member this.dispatcher value =
+            this.Dispatcher([], value)
+            |> this.Run
+            
+        /// The id of the mailbox to use for this actor.
+        /// If undefined or empty the default mailbox of the configured dispatcher
+        /// is used or if there is no mailbox configuration the mailbox specified
+        /// in code (Props.withMailbox) is used.
+        /// If there is a mailbox defined in the configured dispatcher then that
+        /// overrides this setting.
+        [<CustomOperation("mailbox");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Mailbox (state: string list, value: string) =
+            quotedField "mailbox" value::state
+        /// The id of the mailbox to use for this actor.
+        /// If undefined or empty the default mailbox of the configured dispatcher
+        /// is used or if there is no mailbox configuration the mailbox specified
+        /// in code (Props.withMailbox) is used.
+        /// If there is a mailbox defined in the configured dispatcher then that
+        /// overrides this setting.
+        member this.mailbox value =
+            this.Mailbox([], value)
+            |> this.Run
+            
+        /// Routing (load-balance) scheme to use.
+        ///
+        /// - available: 
+        /// "from-code", "round-robin", "random", "smallest-mailbox",
+        /// "scatter-gather", "broadcast"
+        ///
+        /// - or:
+        /// Fully qualified class name of the router class.
+        /// The class must extend akka.routing.CustomRouterConfig and
+        /// have a public constructor with com.typesafe.config.Config
+        /// and optional akka.actor.DynamicAccess parameter.
+        ///
+        /// - default is "from-code";
+        ///
+        /// Whether or not an actor is transformed to a Router is decided in code
+        /// only (Props.withRouter). The type of router can be overridden in the
+        /// configuration; specifying "from-code" means that the values specified
+        /// in the code shall be used.
+        ///
+        /// In case of routing, the actors to be routed to can be specified
+        /// in several ways:
+        ///
+        /// - nr-of-instances: will create that many children
+        ///
+        /// - routees.paths: will route messages to these paths using ActorSelection,
+        ///   i.e. will not create children
+        ///
+        /// - resizer: dynamically resizable number of routees as specified in 
+        /// resizer
+        [<CustomOperation("router");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Router (state: string list, value: Hocon.Router.LoadBalance) =
+            quotedField "router" value.Text::state
+        /// Routing (load-balance) scheme to use.
+        ///
+        /// - available: 
+        /// "from-code", "round-robin", "random", "smallest-mailbox",
+        /// "scatter-gather", "broadcast"
+        ///
+        /// - or:
+        /// Fully qualified class name of the router class.
+        /// The class must extend akka.routing.CustomRouterConfig and
+        /// have a public constructor with com.typesafe.config.Config
+        /// and optional akka.actor.DynamicAccess parameter.
+        ///
+        /// - default is "from-code";
+        ///
+        /// Whether or not an actor is transformed to a Router is decided in code
+        /// only (Props.withRouter). The type of router can be overridden in the
+        /// configuration; specifying "from-code" means that the values specified
+        /// in the code shall be used.
+        ///
+        /// In case of routing, the actors to be routed to can be specified
+        /// in several ways:
+        ///
+        /// - nr-of-instances: will create that many children
+        ///
+        /// - routees.paths: will route messages to these paths using ActorSelection,
+        ///   i.e. will not create children
+        ///
+        /// - resizer: dynamically resizable number of routees as specified in 
+        /// resizer
+        member this.router value =
+            this.Router([], value)
+            |> this.Run
+
+        /// Number of children to create in case of a router;
+        /// this setting is ignored if routees.paths is given
+        [<CustomOperation("nr_of_instances");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.NumberOfInstances (state: string list, value: int) =
+            positiveField "nr-of-instances" value::state
+        /// Number of children to create in case of a router;
+        /// this setting is ignored if routees.paths is given
+        member this.nr_of_instances value =
+            this.NumberOfInstances([], value)
+            |> this.Run
+            
+        /// Within is the timeout used for routers containing future calls
+        [<CustomOperation("within");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.Within (state: string list, value: 'Duration) =
+            durationField "within" value::state
+        /// Within is the timeout used for routers containing future calls
+        member inline this.within (value: 'Duration) =
+            this.Within([], value)
+            |> this.Run
+            
+        /// Number of virtual nodes per node for consistent-hashing router
+        [<CustomOperation("virtual_nodes_factor");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.VirtualNodesFactor (state: string list, value: int) =
+            positiveField "virtual-nodes-factor" value::state
+        /// Number of virtual nodes per node for consistent-hashing router
+        member this.virtual_nodes_factor value =
+            this.VirtualNodesFactor([], value)
+            |> this.Run
+
+        /// MetricsSelector to use
+        ///
+        /// - available: "mix", "heap", "cpu", "load"
+        ///
+        /// - or: Fully qualified class name of the MetricsSelector class.
+        ///       The class must extend akka.cluster.routing.MetricsSelector
+        ///       and have a public constructor with com.typesafe.config.Config
+        ///       parameter.
+        ///
+        /// - default is "mix"
+        [<CustomOperation("metrics_selector");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MetricsSelector (state: string list, value: Hocon.MetricSelection) =
+            field "metrics-selector" value.Text::state
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MetricsSelector (state: string list, value: string) =
+            quotedField "metrics-selector" value::state
+        /// MetricsSelector to use
+        ///
+        /// - available: "mix", "heap", "cpu", "load"
+        ///
+        /// - or: Fully qualified class name of the MetricsSelector class.
+        ///       The class must extend akka.cluster.routing.MetricsSelector
+        ///       and have a public constructor with com.typesafe.config.Config
+        ///       parameter.
+        ///
+        /// - default is "mix"
+        member this.metrics_selector (value: Hocon.MetricSelection) =
+            this.MetricsSelector([], value)
+            |> this.Run
+        /// MetricsSelector to use
+        ///
+        /// - available: "mix", "heap", "cpu", "load"
+        ///
+        /// - or: Fully qualified class name of the MetricsSelector class.
+        ///       The class must extend akka.cluster.routing.MetricsSelector
+        ///       and have a public constructor with com.typesafe.config.Config
+        ///       parameter.
+        ///
+        /// - default is "mix"
+        member this.metrics_selector (value: string) =
+            this.MetricsSelector([], value)
+            |> this.Run
+        
+        // Pathing
+
+        member _.cluster =            
+            { new ClusterBuilder<'T>(mkField, path) with
+                member _.Run (state: SharedInternal.State<Cluster.Target>) : Akka.Shared.Field<'T> =
+                    fun _ -> pathObjExpr "cluster" state.Fields }
+
+        /// Routers with dynamically resizable number of routees; this feature is
+        /// enabled by including (parts of) this section in the deployment
+        member _.resizer = 
+            { new ResizerBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "resizer" state }
+
+        member _.routees =
+            { new RouteesBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "routees" state }
+
+    /// Deployment actor configuration
+    let deploy (name: string) =
+        let indent = 4
+
+        { new DeployeeBuilder<Akka.Actor.Deployment.Field>(Akka.Actor.Deployment.Field, name, indent) with
+            member _.Run (state: string list) =
+                objExpr name indent state
+                |> Akka.Actor.Deployment.Field }
+
+    /// Deployment id pattern - on the format: /parent/child etc.
+    let default' = deploy "default"
+    
+    [<AbstractClass>]
+    type DeploymentBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string, indent: int) =
+        inherit BaseBuilder<'T>()
+
+        let pathObjExpr = pathObjExpr mkField path indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Actor.Deployment.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Shared.Field<Akka.Actor.Deployment.Field>) = [(x indent).ToString()]
+        
+        // Pathing
+
+        /// Deployment actor configuration
+        member _.deploy (name: string) =
+            let path = sprintf "%s.%s" path name
+
+            { new DeployeeBuilder<'T>(mkField, path, indent) with
+                member _.Run (state: string list) = pathObjExpr name state }
+        
+        /// Deployment id pattern - on the format: /parent/child etc.
+        member this.default' = this.deploy "default"
+
+    let deployment = 
+        let path = "deployment"
+        let indent = 3
+
+        { new DeploymentBuilder<Akka.Actor.Field>(Akka.Actor.Field, path, indent) with
+            member _.Run (state: string list) =
+                objExpr path indent state
+                |> Akka.Actor.Field }

--- a/src/Akkling.Hocon/Actor.Dispatcher.fs
+++ b/src/Akkling.Hocon/Actor.Dispatcher.fs
@@ -1,0 +1,336 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Dispatcher =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+    
+    /// For running in current synchronization contexts
+    let current_context_executor = 
+        { new BaseBuilder<Akka.Actor.CurrentContextExecutor.Field>() with
+            member _.Run (state: string list) =
+                objExpr "current-context-executor" 4 state
+                |> Akka.Actor.CurrentContextExecutor.Field }
+    
+    /// This will be used if you have set "executor = "default-executor" (and by default)"
+    let default_executor = 
+        { new BaseBuilder<Akka.Actor.DefaultExecutor.Field>() with
+            member _.Run (state: string list) =
+                objExpr "default-executor" 4 state
+                |> Akka.Actor.DefaultExecutor.Field }
+
+    [<AbstractClass>]
+    type ForkJoinExecutorBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+            
+        /// Min number of threads to cap factor-based parallelism number to
+        [<CustomOperation("parallelism_min");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ParallelismMin (state: string list, value: int) =
+            positiveField "parallelism-min" value::state
+        /// Min number of threads to cap factor-based parallelism number to
+        member this.parallelism_min value =
+            this.ParallelismMin([], value)
+            |> this.Run
+            
+        /// Min number of threads to cap factor-based parallelism number to
+        [<CustomOperation("parallelism_factor");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ParallelismFactor (state: string list, value) =
+            positiveFieldf "parallelism-factor" value::state
+        /// Min number of threads to cap factor-based parallelism number to
+        member this.parallelism_factor value =
+            this.ParallelismFactor([], value)
+            |> this.Run
+            
+        /// Max number of threads to cap factor-based parallelism number to
+        [<CustomOperation("parallelism_max");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ParallelismMax (state: string list, value: int) =
+            positiveField "parallelism-max" value::state
+        /// Max number of threads to cap factor-based parallelism number to
+        member this.parallelism_max value =
+            this.ParallelismMax([], value)
+            |> this.Run
+            
+        /// Setting to "FIFO" to use queue like peeking mode which "poll" or "LIFO" to use stack
+        /// like peeking mode which "pop".
+        [<CustomOperation("task_peeking_mode");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TaskPeekingMode (state: string list, value: Hocon.TaskPeekingMode) =
+            field "task-peeking-mode" value.Text::state
+        /// Setting to "FIFO" to use queue like peeking mode which "poll" or "LIFO" to use stack
+        /// like peeking mode which "pop".
+        member this.task_peeking_mode value =
+            this.TaskPeekingMode([], value)
+            |> this.Run
+            
+    /// This will be used if you have set "executor = "fork-join-executor""
+    ///
+    /// Underlying thread pool implementation is scala.concurrent.forkjoin.ForkJoinPool
+    let fork_join_executor = 
+        { new ForkJoinExecutorBuilder<Akka.Actor.ForkJoinExecutor.Field>() with
+            member _.Run (state: string list) =
+                objExpr "fork-join-executor" 4 state
+                |> Akka.Actor.ForkJoinExecutor.Field }
+
+    /// This will be used if you have set "executor = "thread-pool-executor""
+    let thread_pool_executor = 
+        { new BaseBuilder<Akka.Actor.ThreadPoolExecutor.Field>() with
+            member _.Run (state: string list) =
+                objExpr "thread-pool-executor" 4 state
+                |> Akka.Actor.ThreadPoolExecutor.Field }
+    
+    [<AbstractClass>]
+    type DedicatedThreadPoolBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+            
+        /// Number of threads
+        [<CustomOperation("thread_count");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ThreadCount (state: string list, value: int) =
+            positiveField "thread-count" value::state
+        /// Number of threads
+        member this.thread_count value =
+            this.ThreadCount([], value)
+            |> this.Run
+            
+        [<CustomOperation("deadlock_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.DeadlockTimeout (state: string list, value: 'Duration) =
+            durationField "deadlock-timeout" value::state
+        member inline this.deadlock_timeout (value: 'Duration) =
+            this.DeadlockTimeout([], value)
+            |> this.Run
+            
+        [<CustomOperation("threadtype");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Threadtype (state: string list, x: Hocon.ThreadType) =
+            field "threadtype" x.Text::state
+        member this.threadtype value =
+            this.Threadtype([], value)
+            |> this.Run
+            
+    /// Settings for Helios.DedicatedThreadPool
+    let dedicated_thread_pool = 
+        { new DedicatedThreadPoolBuilder<Akka.Actor.DedicatedThreadPool.Field>() with
+            member _.Run (state: string list) =
+                objExpr "dedicated-thread-pool" 4 state
+                |> Akka.Actor.DedicatedThreadPool.Field }
+    
+    [<AbstractClass>]
+    type DispatcherBuilder<'T when 'T :> IField> (name: string, mkField: string -> 'T, path: string, indent: int) =
+        inherit BaseBuilder<'T>()
+
+        let pathObjExpr = pathObjExpr mkField (sprintf "%s.%s" path name) indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Actor.CurrentContextExecutor.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Actor.DefaultExecutor.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Actor.ForkJoinExecutor.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Actor.ThreadPoolExecutor.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Actor.DedicatedThreadPool.Field) = [x.ToString()]
+            
+        /// For BalancingDispatcher: If the balancing dispatcher should attempt to
+        /// schedule idle actors using the same dispatcher when a message comes in,
+        /// and the dispatchers ExecutorService is not fully busy already.
+        [<CustomOperation("attempt_teamwork");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AttemptTeamwork (state: string list, value: bool) = 
+            switchField "attempt-teamwork" value::state
+        /// For BalancingDispatcher: If the balancing dispatcher should attempt to
+        /// schedule idle actors using the same dispatcher when a message comes in,
+        /// and the dispatchers ExecutorService is not fully busy already.
+        member this.attempt_teamwork value =
+            this.AttemptTeamwork([], value)
+            |> this.Run
+
+        /// Must be one of the following
+        /// Dispatcher, PinnedDispatcher, or a FQCN to a class inheriting
+        /// MessageDispatcherConfigurator with a public constructor with
+        /// both com.typesafe.config.Config parameter and
+        /// akka.dispatch.DispatcherPrerequisites parameters.
+        ///
+        /// PinnedDispatcher must be used together with executor=fork-join-executor.
+        [<CustomOperation("type'");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Type' (state: string list, x: Hocon.Dispatcher) =
+            field "type" x.Text::state
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Type' (state: string list, x: string) =
+            quotedField "type" x::state
+        /// Must be one of the following
+        /// Dispatcher, PinnedDispatcher, or a FQCN to a class inheriting
+        /// MessageDispatcherConfigurator with a public constructor with
+        /// both com.typesafe.config.Config parameter and
+        /// akka.dispatch.DispatcherPrerequisites parameters.
+        ///
+        /// PinnedDispatcher must be used together with executor=fork-join-executor.
+        member this.type' (value: Hocon.Dispatcher) =
+            this.Type'([], value)
+            |> this.Run
+        /// Must be one of the following
+        /// Dispatcher, PinnedDispatcher, or a FQCN to a class inheriting
+        /// MessageDispatcherConfigurator with a public constructor with
+        /// both com.typesafe.config.Config parameter and
+        /// akka.dispatch.DispatcherPrerequisites parameters.
+        ///
+        /// PinnedDispatcher must be used together with executor=fork-join-executor.
+        member this.type' (value: string) =
+            this.Type'([], value)
+            |> this.Run
+            
+        /// Which kind of ExecutorService to use for this dispatcher
+        ///
+        /// Valid options:
+        /// - "default-executor" requires a "default-executor" section
+        ///
+        /// - "fork-join-executor" requires a "fork-join-executor" section
+        ///
+        /// - "thread-pool-executor" requires a "thread-pool-executor" section
+        ///
+        /// - "current-context-executor" requires a "current-context-executor" section
+        ///
+        /// - "task-executor" requires a "task-executor" section
+        ///
+        /// - A FQCN of a class extending ExecutorServiceConfigurator
+        [<CustomOperation("executor");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Executor (state: string list, x: Hocon.Executor) =
+            quotedField "executor" x.Text::state
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Executor (state: string list, x: string) =
+            quotedField "executor" x::state
+        /// Which kind of ExecutorService to use for this dispatcher
+        ///
+        /// Valid options:
+        /// - "default-executor" requires a "default-executor" section
+        ///
+        /// - "fork-join-executor" requires a "fork-join-executor" section
+        ///
+        /// - "thread-pool-executor" requires a "thread-pool-executor" section
+        ///
+        /// - "current-context-executor" requires a "current-context-executor" section
+        ///
+        /// - "task-executor" requires a "task-executor" section
+        ///
+        /// - A FQCN of a class extending ExecutorServiceConfigurator
+        member this.executor (value: Hocon.Executor) =
+            this.Executor([], value)
+            |> this.Run
+        /// Which kind of ExecutorService to use for this dispatcher
+        ///
+        /// Valid options:
+        /// - "default-executor" requires a "default-executor" section
+        ///
+        /// - "fork-join-executor" requires a "fork-join-executor" section
+        ///
+        /// - "thread-pool-executor" requires a "thread-pool-executor" section
+        ///
+        /// - "current-context-executor" requires a "current-context-executor" section
+        ///
+        /// - "task-executor" requires a "task-executor" section
+        ///
+        /// - A FQCN of a class extending ExecutorServiceConfigurator
+        member this.executor (value: string) =
+            this.Executor([], value)
+            |> this.Run
+            
+        /// If this dispatcher requires a specific type of mailbox, specify the
+        /// fully-qualified class name here; the actually created mailbox will
+        /// be a subtype of this type. 
+        ///
+        /// An empty string signifies no requirement.
+        [<CustomOperation("mailbox_requirement");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MailboxRequirement (state: string list, x: string) =
+            quotedField "mailbox-requirement" x::state
+        /// If this dispatcher requires a specific type of mailbox, specify the
+        /// fully-qualified class name here; the actually created mailbox will
+        /// be a subtype of this type. 
+        ///
+        /// An empty string signifies no requirement.
+        member this.mailbox_requirement value =
+            this.MailboxRequirement([], value)
+            |> this.Run
+
+        /// How long time the dispatcher will wait for new actors until it shuts down
+        [<CustomOperation("shutdown_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ShutdownTimeout (state: string list, value: 'Duration) =
+            durationField "shutdown-timeout" value::state
+        /// How long time the dispatcher will wait for new actors until it shuts down
+        member inline this.shutdown_timeout (value: 'Duration) =
+            this.ShutdownTimeout([], value)
+            |> this.Run
+            
+        /// Throughput defines the number of messages that are processed in a batch
+        /// before the thread is returned to the pool. 
+        ///
+        /// Set to 1 for as fair as possible.
+        [<CustomOperation("throughput");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Throughput (state: string list, value: int) =
+            positiveField "throughput" value::state
+        /// Throughput defines the number of messages that are processed in a batch
+        /// before the thread is returned to the pool. 
+        ///
+        /// Set to 1 for as fair as possible.
+        member this.throughput value =
+            this.Throughput([], value)
+            |> this.Run
+            
+        /// Throughput deadline for Dispatcher, set to 0 for no deadline
+        [<CustomOperation("throughput_deadline_time");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ThroughputDeadlineTime (state: string list, value: 'Duration) =
+            durationField "throughput-deadline-time" value::state
+        /// Throughput deadline for Dispatcher, set to 0 for no deadline
+        member inline this.throughput_deadline_time (value: 'Duration) =
+            this.ThroughputDeadlineTime([], value)
+            |> this.Run
+
+        // Pathing
+
+        member _.current_context_executor = 
+            { new BaseBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "current-context-executor" state }
+        
+        /// This will be used if you have set "executor = "default-executor" (and by default)"
+        member _.default_executor = 
+            { new BaseBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "default-executor" state }
+
+        member _.fork_join_executor = 
+            { new ForkJoinExecutorBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "fork-join-executor" state }
+
+        /// This will be used if you have set "executor = "thread-pool-executor""
+        member _.thread_pool_executor = 
+            { new BaseBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "thread-pool-executor" state }
+
+        member _.dedicated_thread_pool = 
+            { new DedicatedThreadPoolBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "dedicated-thread-pool" state }
+    
+    let custom_dispatcher (name: string) =
+        let indent = 3
+
+        { new DispatcherBuilder<Akka.Actor.Dispatcher.Field>(name, Akka.Actor.Dispatcher.Field, name, indent) with
+            member _.Run (state: string list) =
+                objExpr name indent state
+                |> Akka.Actor.Dispatcher.Field }
+
+    let backoff_remote_dispatcher = custom_dispatcher "backoff-remote-dispatcher"
+    let calling_thread_dispatcher = custom_dispatcher "calling-thread-dispatcher"
+    let default_dispatcher = custom_dispatcher "default-dispatcher"
+    let dispatcher = custom_dispatcher "dispatcher"
+    let default_blocking_io_dispatcher = custom_dispatcher "default-blocking-io-dispatcher"
+    let default_fork_join_dispatcher = custom_dispatcher "default-fork-join-dispatcher"
+    let default_plugin_dispatcher = custom_dispatcher "default-plugin-dispatcher"
+    let default_remote_dispatcher = custom_dispatcher "default-remote-dispatcher"
+    let default_replay_dispatcher = custom_dispatcher "default-replay-dispatcher"
+    let default_stream_dispatcher = custom_dispatcher "default-stream-dispatcher"
+
+    /// Default separate internal dispatcher to run Akka internal tasks and actors on
+    /// protecting them against starvation because of accidental blocking in user actors (which run on the
+    /// default dispatcher
+    let internal_dispatcher = custom_dispatcher "internal-dispatcher"
+
+    let pinned_dispatcher = custom_dispatcher "pinned-dispatcher"
+
+    /// Used for GUI applications
+    let synchronized_dispatcher = custom_dispatcher "synchronized-dispatcher"
+    let task_dispatcher = custom_dispatcher "task-dispatcher"

--- a/src/Akkling.Hocon/Actor.Inbox.fs
+++ b/src/Akkling.Hocon/Actor.Inbox.fs
@@ -1,0 +1,31 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Inbox =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type InboxBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        [<CustomOperation("default_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.DefaultTimeout (state: string list, value: 'Duration) =
+            durationField "default-timeout" value::state
+        member inline this.default_timeout (value: 'Duration) =
+            this.DefaultTimeout([], value)
+            |> this.Run
+
+        [<CustomOperation("inbox_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.InboxSize (state: string list, value: int) =
+            positiveField "inbox-size" value::state
+        member this.inbox_size value =
+            this.InboxSize([], value)
+            |> this.Run
+
+    let inbox = 
+        { new InboxBuilder<Akka.Actor.Field>() with
+            member _.Run (state: string list) =
+                objExpr "inbox" 3 state
+                |> Akka.Actor.Field }

--- a/src/Akkling.Hocon/Actor.Mailbox.fs
+++ b/src/Akkling.Hocon/Actor.Mailbox.fs
@@ -1,0 +1,130 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Mailbox =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type MailboxBasedBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        /// FQCN of the MailboxType. The Class of the FQCN must have a public
+        /// constructor with
+        /// (akka.actor.ActorSystem.Settings, com.typesafe.config.Config) parameters.
+        [<CustomOperation("mailbox_type");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MailboxType (state: string list, x: string) =
+            quotedField "mailbox-type" x::state
+        /// FQCN of the MailboxType. The Class of the FQCN must have a public
+        /// constructor with
+        /// (akka.actor.ActorSystem.Settings, com.typesafe.config.Config) parameters.
+        member this.mailbox_type value =
+            this.MailboxType([], value)
+            |> this.Run
+            
+        /// If the mailbox is bounded then it uses this setting to determine its
+        /// capacity. The provided value must be positive.
+        ///
+        /// NOTICE:
+        /// Up to version 2.1 the mailbox type was determined based on this setting;
+        /// this is no longer the case, the type must explicitly be a bounded mailbox.
+        [<CustomOperation("mailbox_capacity");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MailboxCapacity (state: string list, value: int) =
+            positiveField "mailbox-capacity" value::state
+        /// If the mailbox is bounded then it uses this setting to determine its
+        /// capacity. The provided value must be positive.
+        ///
+        /// NOTICE:
+        /// Up to version 2.1 the mailbox type was determined based on this setting;
+        /// this is no longer the case, the type must explicitly be a bounded mailbox.
+        member this.mailbox_capacity value =
+            this.MailboxCapacity([], value)
+            |> this.Run
+            
+        /// If the mailbox is bounded then this is the timeout for enqueueing
+        /// in case the mailbox is full. Negative values signify infinite
+        /// timeout, which should be avoided as it bears the risk of dead-lock.
+        [<CustomOperation("mailbox_push_timeout_time");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.MailboxPushTimeoutTime (state: string list, value: 'Duration) =
+            durationField "mailbox-push-timeout-time" value::state
+        /// If the mailbox is bounded then this is the timeout for enqueueing
+        /// in case the mailbox is full. Negative values signify infinite
+        /// timeout, which should be avoided as it bears the risk of dead-lock.
+        member inline this.mailbox_push_timeout_time (value: 'Duration) =
+            this.MailboxPushTimeoutTime([], value)
+            |> this.Run
+            
+        /// For Actor with Stash: The default capacity of the stash.
+        /// If negative (or zero) then an unbounded stash is used (default)
+        /// If positive then a bounded stash is used and the capacity is set using
+        /// the property
+        [<CustomOperation("stash_capacity");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.StashCapacity (state: string list, value: int) =
+            numField "stash-capacity" value::state
+        /// For Actor with Stash: The default capacity of the stash.
+        /// If negative (or zero) then an unbounded stash is used (default)
+        /// If positive then a bounded stash is used and the capacity is set using
+        /// the property
+        member this.stash_capacity value =
+            this.StashCapacity([], value)
+            |> this.Run
+            
+    let private createMailbox name =
+        { new MailboxBasedBuilder<Akka.Actor.Mailbox.Field>() with
+            member _.Run (state: string list) =
+                objExpr name 4 state
+                |> Akka.Actor.Mailbox.Field }
+
+    let bounded_deque_based = createMailbox "bounded-deque-based"
+    let bounded_queue_based = createMailbox "bounded-queue-based"
+
+    /// The LoggerMailbox will drain all messages in the mailbox
+    /// when the system is shutdown and deliver them to the StandardOutLogger.
+    ///
+    /// Do not change this unless you know what you are doing.
+    let logger_queue = createMailbox "logger-queue"
+    let unbounded_deque_based = createMailbox "unbounded-deque-based"
+    let unbounded_queue_based = createMailbox "unbounded-queue-based"
+    
+    [<AbstractClass>]
+    type MailboxBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string, indent: int) =
+        inherit BaseBuilder<'T>()
+        
+        let pathObjExpr = pathObjExpr mkField path indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Actor.Mailbox.Field) = [x.ToString()]
+
+        [<CustomOperation("requirements");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Requirements (state: string list, xs: (string * string) list) =
+            stringyObjExpr "requirements" 4 xs::state
+        member this.requirements value =
+            this.Requirements([], value)
+            |> this.Run
+
+        // Pathing
+
+        member private _.createMailbox name =
+            { new MailboxBasedBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr name state }
+
+        member this.bounded_deque_based = this.createMailbox "bounded-deque-based"
+        member this.bounded_queue_based = this.createMailbox "bounded-queue-based"
+
+        /// The LoggerMailbox will drain all messages in the mailbox
+        /// when the system is shutdown and deliver them to the StandardOutLogger.
+        ///
+        /// Do not change this unless you know what you are doing.
+        member this.logger_queue = this.createMailbox "logger-queue"
+        member this.unbounded_deque_based = this.createMailbox "unbounded-deque-based"
+        member this.unbounded_queue_based = this.createMailbox "unbounded-queue-based"
+
+    let mailbox =
+        let path = "mailbox"
+        let indent = 3
+
+        { new MailboxBuilder<Akka.Actor.Field>(Akka.Actor.Field, path, indent) with
+            member _.Run (state: string list) =
+                objExpr path indent state
+                |> Akka.Actor.Field }

--- a/src/Akkling.Hocon/Actor.Router.fs
+++ b/src/Akkling.Hocon/Actor.Router.fs
@@ -1,0 +1,153 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Router =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type TypeMappingBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        [<CustomOperation("from_code");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.FromCode (state: string list, x: string) =
+            quotedField "from-code" x::state
+        member this.from_code value =
+            this.FromCode([], value)
+            |> this.Run
+        
+        [<CustomOperation("round_robin_pool");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.RoundRobinPool (state: string list, x: string) =
+            quotedField "round-robin-pool" x::state
+        member this.round_robin_pool value =
+            this.RoundRobinPool([], value)
+            |> this.Run
+    
+        [<CustomOperation("round_robin_group");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.RoundRobinGroup (state: string list, x: string) =
+            quotedField "round-robin-group" x::state
+        member this.round_robin_group value =
+            this.RoundRobinGroup([], value)
+            |> this.Run
+    
+        [<CustomOperation("random_pool");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.RandomPool (state: string list, x: string) =
+            quotedField "random-pool" x::state
+        member this.random_pool value =
+            this.RandomPool([], value)
+            |> this.Run
+    
+        [<CustomOperation("random_group");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.RandomGroup (state: string list, x: string) =
+            quotedField "random-group" x::state
+        member this.random_group value =
+            this.RandomGroup([], value)
+            |> this.Run
+    
+        [<CustomOperation("smallest_mailbox_pool");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SmallestMailboxPool (state: string list, x: string) =
+            quotedField "smallest-mailbox-pool" x::state
+        member this.smallest_mailbox_pool value =
+            this.SmallestMailboxPool([], value)
+            |> this.Run
+    
+        [<CustomOperation("broadcast_pool");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.BroadcastPool (state: string list, x: string) =
+            quotedField "broadcast-pool" x::state
+        member this.broadcast_pool value =
+            this.BroadcastPool([], value)
+            |> this.Run
+    
+        [<CustomOperation("broadcast_group");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.BroadcastGroup (state: string list, x: string) =
+            quotedField "broadcast-group" x::state
+        member this.broadcast_group value =
+            this.BroadcastGroup([], value)
+            |> this.Run
+    
+        [<CustomOperation("scatter_gather_pool");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ScatterGatherPool (state: string list, x: string) =
+            quotedField "scatter-gather-pool" x::state
+        member this.scatter_gather_pool value =
+            this.ScatterGatherPool([], value)
+            |> this.Run
+    
+        [<CustomOperation("scatter_gather_group");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ScatterGatherGroup (state: string list, x: string) =
+            quotedField "scatter-gather-group" x::state
+        member this.scatter_gather_group value =
+            this.ScatterGatherGroup([], value)
+            |> this.Run
+    
+        [<CustomOperation("consistent_hashing_pool");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ConsistentHashingPool (state: string list, x: string) =
+            quotedField "consistent-hashing-pool" x::state
+        member this.consistent_hashing_pool value =
+            this.ConsistentHashingPool([], value)
+            |> this.Run
+    
+        [<CustomOperation("consistent_hashing_group");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ConsistentHashingGroup (state: string list, x: string) =
+            quotedField "consistent-hashing-group" x::state
+        member this.consistent_hashing_group value =
+            this.ConsistentHashingGroup([], value)
+            |> this.Run
+    
+        [<CustomOperation("tail_chopping_pool");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TailChoppingPool (state: string list, x: string) =
+            quotedField "tail-chopping-pool" x::state
+        member this.tail_chopping_pool value =
+            this.TailChoppingPool([], value)
+            |> this.Run
+    
+        [<CustomOperation("tail_chopping_group");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TailChoppingGroup (state: string list, x: string) =
+            quotedField "tail-chopping-group" x::state
+        member this.tail_chopping_group value =
+            this.TailChoppingGroup([], value)
+            |> this.Run
+    
+        [<CustomOperation("cluster_metrics_adaptive_pool");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ClusterMetricsAdaptivePool (state: string list, x: string) =
+            quotedField "cluster-metrics-adaptive-pool" x::state
+        member this.cluster_metrics_adaptive_pool value =
+            this.ClusterMetricsAdaptivePool([], value)
+            |> this.Run
+    
+        [<CustomOperation("cluster_metrics_adaptive_group");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ClusterMetricsAdaptiveGroup (state: string list, x: string) =
+            quotedField "cluster-metrics-adaptive-group" x::state
+        member this.cluster_metrics_adaptive_group value =
+            this.ClusterMetricsAdaptiveGroup([], value)
+            |> this.Run
+
+    let type_mapping = 
+        { new TypeMappingBuilder<Akka.Actor.Router.Field>() with
+            member _.Run (state: string list) =
+                objExpr "type-mapping" 4 state
+                |> Akka.Actor.Router.Field }
+
+    [<AbstractClass>]
+    type RouterBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string, indent: int) =
+        inherit BaseBuilder<'T>()
+
+        let pathObjExpr = pathObjExpr mkField path indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Actor.Router.Field) = [x.ToString()]
+
+        // Pathing
+
+        member _.type_mapping =
+            { new TypeMappingBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "type-mapping" state }
+
+    let router = 
+        let path = "router"
+        let indent = 3
+
+        { new RouterBuilder<Akka.Actor.Field>(Akka.Actor.Field, path, indent) with
+            member _.Run (state: string list) =
+                objExpr path indent state
+                |> Akka.Actor.Field }

--- a/src/Akkling.Hocon/Actor.Serializers.fs
+++ b/src/Akkling.Hocon/Actor.Serializers.fs
@@ -1,0 +1,174 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Serializers =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    type Serializers =
+        /// akka-cluster
+        static member akka_cluster = "akka-cluster"
+        
+        /// akka-cluster-client
+        static member akka_cluster_client = "akka-cluster-client"
+        
+        /// akka-cluster-metrics
+        static member akka_cluster_metrics = "akka-cluster-metrics"
+
+        /// akka-containers
+        static member akka_containers = "akka-containers"
+
+        /// akka-misc
+        static member akka_misc = "akka-misc"
+
+        /// akka-persistence-message
+        static member akka_persistence_message = "akka-persistence-message"
+        
+        /// akka-persistence-snapshot
+        static member akka_persistence_snapshot = "akka-persistence-snapshot"
+
+        /// akka-stream-ref
+        static member akka_stream_ref = "akka-stream-ref"
+        
+        /// akka-system-msg
+        static member akka_system_msg = "akka-system-msg"
+
+        /// bytes
+        static member bytes = "bytes"
+        
+        /// daemon-create
+        static member daemon_create = "daemon-create"
+        
+        /// hyperion
+        static member hyperion = "hyperion"
+
+        /// json
+        static member json = "json"
+        
+        /// primative
+        static member primitive = "primitive"
+
+        /// proto
+        static member proto = "proto"
+
+    [<AbstractClass>]
+    type SerializersBuilder<'T when 'T :> MarkerClasses.IField> () =
+        inherit BaseBuilder<'T>()
+        
+        [<CustomOperation("akka_cluster");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AkkaCluster (state: string list, value: string) =
+            quotedField Serializers.akka_cluster value::state
+        member this.akka_cluster value =
+            this.AkkaCluster([], value)
+            |> this.Run
+        
+        [<CustomOperation("akka_cluster_client");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AkkaClusterClient (state: string list, value: string) =
+            quotedField Serializers.akka_cluster_client value::state
+        member this.akka_cluster_client value =
+            this.AkkaClusterClient([], value)
+            |> this.Run
+        
+        [<CustomOperation("akka_cluster_metrics");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AkkaClusterMetrics (state: string list, value: string) =
+            quotedField Serializers.akka_cluster_metrics value::state
+        member this.akka_cluster_metrics value =
+            this.AkkaClusterClient([], value)
+            |> this.Run
+        
+        [<CustomOperation("akka_containers");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AkkaContainers (state: string list, value: string) =
+            quotedField Serializers.akka_containers value::state
+        member this.akka_containers value =
+            this.AkkaContainers([], value)
+            |> this.Run
+        
+        [<CustomOperation("akka_misc");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AkkaMisc (state: string list, value: string) =
+            quotedField Serializers.akka_misc value::state
+        member this.akka_misc value =
+            this.AkkaMisc([], value)
+            |> this.Run
+        
+        [<CustomOperation("akka_persistence_message");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AkkaPersistenceMessage (state: string list, value: string) =
+            quotedField Serializers.akka_persistence_message value::state
+        member this.akka_persistence_message value =
+            this.AkkaPersistenceMessage([], value)
+            |> this.Run
+        
+        [<CustomOperation("akka_persistence_snapshot");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AkkaPersistenceSnapshot (state: string list, value: string) =
+            quotedField Serializers.akka_persistence_snapshot value::state
+        member this.akka_persistence_snapshot value =
+            this.AkkaPersistenceSnapshot([], value)
+            |> this.Run
+            
+        [<CustomOperation("akka_stream_ref");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AkkaStreamRef (state: string list, value: string) =
+            quotedField Serializers.akka_stream_ref value::state
+        member this.akka_stream_ref value =
+            this.AkkaStreamRef([], value)
+            |> this.Run
+            
+        [<CustomOperation("akka_system_msg");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AkkaSystemMessage (state: string list, value: string) =
+            quotedField Serializers.akka_system_msg value::state
+        member this.akka_system_msg value =
+            this.AkkaSystemMessage([], value)
+            |> this.Run
+            
+        [<CustomOperation("bytes");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Bytes (state: string list, value: string) =
+            quotedField Serializers.bytes value::state
+        member this.bytes value =
+            this.Bytes([], value)
+            |> this.Run
+            
+        [<CustomOperation("daemon_create");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.DaemonCreate (state: string list, value: string) =
+            quotedField Serializers.daemon_create value::state
+        member this.daemon_create value =
+            this.DaemonCreate([], value)
+            |> this.Run
+            
+        [<CustomOperation("hyperion");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Hyperion (state: string list, value: string) =
+            quotedField Serializers.hyperion value::state
+        member this.hyperion value =
+            this.Hyperion([], value)
+            |> this.Run
+            
+        [<CustomOperation("json");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Json (state: string list, value: string) =
+            quotedField Serializers.json value::state
+        member this.json value =
+            this.Json([], value)
+            |> this.Run
+            
+        [<CustomOperation("primitive");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Primitive (state: string list, value: string) =
+            quotedField Serializers.primitive value::state
+        member this.primitive value =
+            this.Primitive([], value)
+            |> this.Run
+            
+        [<CustomOperation("proto");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Proto (state: string list, value: string) =
+            quotedField Serializers.proto value::state
+        member this.proto value =
+            this.Proto([], value)
+            |> this.Run
+
+    let serializers = 
+        { new SerializersBuilder<Akka.Actor.Field>() with
+            member _.Run (state: string list) =
+                objExpr "serializers" 3 state
+                |> Akka.Actor.Field }
+
+    let serialization_settings = 
+        { new BaseBuilder<Akka.Actor.Field>() with
+            member _.Run (state: string list) =
+                objExpr "serialization-settings" 3 state
+                |> Akka.Actor.Field }

--- a/src/Akkling.Hocon/Actor.Typed.fs
+++ b/src/Akkling.Hocon/Actor.Typed.fs
@@ -1,0 +1,26 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Typed =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type TypedBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        [<CustomOperation("timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.Timeout (state: string list, value: 'Duration) =
+            durationField "timeout" value::state
+        member inline this.timeout (value: 'Duration) =
+            this.Timeout([], value)
+            |> this.Run
+
+    /// THIS DOES NOT APPLY TO .NET
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    let typed' = 
+        { new TypedBuilder<Akka.Actor.Field>() with
+            member _.Run (state: string list) =
+                objExpr "typed" 3 state
+                |> Akka.Actor.Field }

--- a/src/Akkling.Hocon/Actor.fs
+++ b/src/Akkling.Hocon/Actor.fs
@@ -1,0 +1,257 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Actor =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+    
+    [<AbstractClass>]
+    type ActorBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        let indent = 2
+        let pathObjExpr = pathObjExpr Akka.Field "actor" indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Shared.Field<Akka.Shared.Debug.Field>) = [(x 3).ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Shared.Field<Akka.Actor.Field>) = [(x indent).ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Actor.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Actor.Dispatcher.Field) = [x.ToString()]
+
+        /// Default timeout for IActorRef.Ask.
+        [<CustomOperation("ask_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.AskTimeout (state: string list, value: 'Duration) =
+            durationField "ask-timeout" value::state
+        member _.AskTimeout (state: string list, value: Hocon.Infinite) =
+            field "ask-timeout" (value.ToString())::state
+
+        /// Default timeout for IActorRef.Ask.
+        member inline this.ask_timeout (value: 'Duration) =
+            this.AskTimeout([], value)
+            |> this.Run
+        /// Default timeout for IActorRef.Ask.
+        member this.ask_timeout (value: Hocon.Infinite) =
+            this.AskTimeout([], value)
+            |> this.Run
+
+        /// Timeout for ActorSystem.actorOf
+        [<CustomOperation("creation_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.CreationTimeout (state: string list, value: 'Duration) =
+            durationField "creation-timeout" value::state
+        /// Timeout for ActorSystem.actorOf
+        member inline this.creation_timeout (value: 'Duration) =
+            this.CreationTimeout([], value)
+            |> this.Run
+
+        /// FQCN of the ActorRefProvider to be used; the below is the built-in default,
+        /// another one is akka.remote.RemoteActorRefProvider in the akka-remote bundle.
+        [<CustomOperation("guardian_supervisor_strategy");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.GuardianSupervisorStrategy (state: string list, x: string) =
+            quotedField "guardian-supervisor-strategy" x::state
+        /// FQCN of the ActorRefProvider to be used; the below is the built-in default,
+        /// another one is akka.remote.RemoteActorRefProvider in the akka-remote bundle.
+        member this.guardian_supervisor_strategy value =
+            this.GuardianSupervisorStrategy([], value)
+            |> this.Run
+
+        /// FQCN of the ActorRefProvider to be used; the below is the built-in default,
+        /// another one is akka.remote.RemoteActorRefProvider in the akka-remote bundle.
+        [<CustomOperation("provider");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Provider (state: string list, x: string) =
+            quotedField "provider" x::state
+        /// FQCN of the ActorRefProvider to be used; the below is the built-in default,
+        /// another one is akka.remote.RemoteActorRefProvider in the akka-remote bundle.
+        member this.provider value =
+            this.Provider([], value)
+            |> this.Run
+
+        /// Frequency with which stopping actors are prodded in case they had to be
+        /// removed from their parents.
+        [<CustomOperation("reaper_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ReaperInterval (state: string list, value: int) =
+            positiveField "reaper-interval" value::state
+        /// Frequency with which stopping actors are prodded in case they had to be
+        /// removed from their parents.
+        member this.reaper_interval value =
+            this.ReaperInterval([], value)
+            |> this.Run
+            
+        /// Serializes and deserializes creators (in Props) to ensure that they can be
+        /// sent over the network, this is only intended for testing. Purely local deployments
+        /// as marked with deploy.scope == LocalScope are exempt from verification.
+        [<CustomOperation("serialize_messages");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SerializeMessages (state: string list, value: bool) = 
+            switchField "serialize-messages" value::state
+        /// Serializes and deserializes creators (in Props) to ensure that they can be
+        /// sent over the network, this is only intended for testing. Purely local deployments
+        /// as marked with deploy.scope == LocalScope are exempt from verification.
+        member this.serialize_messages value =
+            this.SerializeMessages([], value)
+            |> this.Run
+
+        /// Serializes and deserializes (non-primitive) messages to ensure immutability,
+        /// this is only intended for testing.
+        [<CustomOperation("serialize_creators");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SerializeCreators (state: string list, value: bool) = 
+            switchField "serialize-creators" value::state
+        /// Serializes and deserializes (non-primitive) messages to ensure immutability,
+        /// this is only intended for testing.
+        member this.serialize_creators value =
+            this.SerializeCreators([], value)
+            |> this.Run
+
+        /// Class to Serializer binding. You only need to specify the name of an
+        /// interface or abstract base class of the messages. In case of ambiguity it
+        /// is using the most specific configured class, or giving a warning and
+        /// choosing the “first” one.
+        /// 
+        /// To disable one of the default serializers, assign its class to "none", like
+        /// "java.io.Serializable" = none
+        [<CustomOperation("serialization_bindings");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SerializationBindings (state: string list, xs: (System.Type * string) list) =
+            stringyObjExpr "serialization-bindings" 4 (xs |> List.map (fun (t,v) -> t.FullName,v))::state
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SerializationBindings (state: string list, xs: (string * string) list) =
+            stringyObjExpr "serialization-bindings" 4 xs::state
+        /// Class to Serializer binding. You only need to specify the name of an
+        /// interface or abstract base class of the messages. In case of ambiguity it
+        /// is using the most specific configured class, or giving a warning and
+        /// choosing the “first” one.
+        /// 
+        /// To disable one of the default serializers, assign its class to "none", like
+        /// "java.io.Serializable" = none
+        member this.serialization_bindings (xs: (string * string) list) =
+            this.SerializationBindings([], xs)
+            |> this.Run
+        /// Class to Serializer binding. You only need to specify the name of an
+        /// interface or abstract base class of the messages. In case of ambiguity it
+        /// is using the most specific configured class, or giving a warning and
+        /// choosing the “first” one.
+        /// 
+        /// To disable one of the default serializers, assign its class to "none", like
+        /// "java.io.Serializable" = none
+        member this.serialization_bindings (xs: (System.Type * string) list) =
+            this.SerializationBindings([], xs)
+            |> this.Run
+
+        /// Configuration namespace of serialization identifiers.
+        /// Each serializer implementation must have an entry in the following format:
+        /// `akka.actor.serialization-identifiers."FQCN" = ID`
+        /// where `FQCN` is fully qualified class name of the serializer implementation
+        /// and `ID` is globally unique serializer identifier number.
+        ///
+        /// Identifier values from 0 to 40 are reserved for Akka internal usage.
+        [<CustomOperation("serialization_identifiers");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SerializationIdentifiers (state: string list, xs: (string * int) list) =
+            stringyObjExpr "serialization-identifiers" 4 (xs |> List.map (fun (t,v) -> t,string v))::state
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SerializationIdentifiers (state: string list, xs: (string * string) list) =
+            stringyObjExpr "serialization-identifiers" 4 xs::state
+        /// Configuration namespace of serialization identifiers.
+        /// Each serializer implementation must have an entry in the following format:
+        /// `akka.actor.serialization-identifiers."FQCN" = ID`
+        /// where `FQCN` is fully qualified class name of the serializer implementation
+        /// and `ID` is globally unique serializer identifier number.
+        ///
+        /// Identifier values from 0 to 40 are reserved for Akka internal usage.
+        member this.serialization_identifiers (xs: (string * int) list) =
+            this.SerializationIdentifiers([], xs)
+            |> this.Run
+        /// Configuration namespace of serialization identifiers.
+        /// Each serializer implementation must have an entry in the following format:
+        /// `akka.actor.serialization-identifiers."FQCN" = ID`
+        /// where `FQCN` is fully qualified class name of the serializer implementation
+        /// and `ID` is globally unique serializer identifier number.
+        ///
+        /// Identifier values from 0 to 40 are reserved for Akka internal usage.
+        member this.serialization_identifiers (xs: (string * string) list) =
+            this.SerializationIdentifiers([], xs)
+            |> this.Run
+
+        /// Timeout for send operations to top-level actors which are in the process
+        /// of being started. This is only relevant if using a bounded mailbox or the
+        /// CallingThreadDispatcher for a top-level actor.
+        [<CustomOperation("unstarted_push_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.UnstartedPushTimeout (state: string list, value: 'Duration) =
+            durationField "unstarted-push-timeout" value::state
+        /// Timeout for send operations to top-level actors which are in the process
+        /// of being started. This is only relevant if using a bounded mailbox or the
+        /// CallingThreadDispatcher for a top-level actor.
+        member inline this.unstarted_push_timeout (value: 'Duration) =
+            this.UnstartedPushTimeout([], value)
+            |> this.Run
+
+        // Pathing
+
+        member _.typed =
+            { new TypedBuilder<Akka.Field>() with
+                member _.Run (state: string list) = pathObjExpr "typed" state }
+
+        member _.deployment = 
+            { new DeploymentBuilder<Akka.Field>(Akka.Field, "actor.deployment", indent) with
+                member _.Run (state: string list) = pathObjExpr "deployment" state }
+
+        member _.router = 
+            { new RouterBuilder<Akka.Field>(Akka.Field, "actor.router", indent) with
+                member _.Run (state: string list) = pathObjExpr "router" state }
+
+        member _.custom_dispatcher (name: string) =
+            let path = sprintf "actor.%s" name
+
+            { new DispatcherBuilder<Akka.Field>(name, Akka.Field, path, indent) with
+                member _.Run (state: string list) = pathObjExpr name state }
+
+        member this.backoff_remote_dispatcher = this.custom_dispatcher "backoff-remote-dispatcher"
+        member this.calling_thread_dispatcher = this.custom_dispatcher "calling-thread-dispatcher"
+        member this.default_dispatcher = this.custom_dispatcher "default-dispatcher"
+        member this.dispatcher = this.custom_dispatcher "dispatcher"
+        member this.default_blocking_io_dispatcher = this.custom_dispatcher "default-blocking-io-dispatcher"
+        member this.default_fork_join_dispatcher = this.custom_dispatcher "default-fork-join-dispatcher"
+        member this.default_plugin_dispatcher = this.custom_dispatcher "default-plugin-dispatcher"
+        member this.default_remote_dispatcher = this.custom_dispatcher "default-remote-dispatcher"
+        member this.default_replay_dispatcher = this.custom_dispatcher "default-replay-dispatcher"
+        member this.default_stream_dispatcher = this.custom_dispatcher "default-stream-dispatcher"
+
+        /// Default separate internal dispatcher to run Akka internal tasks and actors on
+        /// protecting them against starvation because of accidental blocking in user actors (which run on the
+        /// default dispatcher
+        member this.internal_dispatcher = this.custom_dispatcher "internal-dispatcher"
+
+        /// Used for GUI applications
+        member this.synchronized_dispatcher = this.custom_dispatcher "synchronized-dispatcher"
+        member this.task_dispatcher = this.custom_dispatcher "task-dispatcher"
+
+        member _.default_mailbox = 
+            { new DefaultMailboxBuilder<Akka.Field>() with
+                member _.Run (state: string list) = pathObjExpr "default-mailbox" state }
+
+        member _.custom_mailbox (name: string) = 
+            { new DefaultMailboxBuilder<Akka.Field>() with
+                member _.Run (state: string list) = pathObjExpr name state }
+
+        member _.mailbox = 
+            { new MailboxBuilder<Akka.Field>(Akka.Field, "actor.mailbox", indent) with
+                member _.Run (state: string list) = pathObjExpr "mailbox" state }
+
+        member _.serializers = 
+            { new SerializersBuilder<Akka.Field>() with
+                member _.Run (state: string list) = pathObjExpr "serializers" state }
+
+        member _.serialization_settings = 
+            { new BaseBuilder<Akka.Field>() with
+                member _.Run (state: string list) = pathObjExpr "serialization-settings" state }
+
+        member _.debug =            
+            { new DebugBuilder<Akka.Field>() with
+                member _.Run (state: SharedInternal.State<Debug.Target>) : Akka.Shared.Field<Akka.Field> =
+                    fun _ -> pathObjExpr "debug" state.Fields }
+
+    let actor = 
+        { new ActorBuilder<Akka.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "actor" 2 state
+                |> Akka.Field }

--- a/src/Akkling.Hocon/Akka.fs
+++ b/src/Akkling.Hocon/Akka.fs
@@ -1,0 +1,153 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Akka =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+    
+    [<AbstractClass>]
+    type SslConfigBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        /// Home directory of Akka, modules in the deploy directory will be loaded.
+        [<CustomOperation("protocol");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Protocol (state: string list, x: string) = 
+            quotedField "protocol" x::state        
+        /// Home directory of Akka, modules in the deploy directory will be loaded.
+        member this.protocol value =
+            this.Protocol([], value)
+            |> this.Run
+
+    let ssl_config =
+        { new SslConfigBuilder<Akka.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "ssl-config" 2 state
+                |> Akka.Field }
+
+    type AkkaBuilder () =
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: string) = [x]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (a: unit) = []
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Shared.Field<Akka.Shared.Cluster.Field>) = [(x 2).ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Shared.Field<Akka.Field>) = [(x 2).ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Scheduler.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Combine (state: string list, x: string list) = x @ state
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Zero () = []
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Delay f = f()
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.For (xs: string list, f: unit -> string list) = f() @ xs
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Run (state: string list) =
+            objExpr "akka" 1 (state |> List.rev)
+
+        /// Toggles whether threads created by this ActorSystem should be daemons or not.
+        [<CustomOperation("daemonic");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Daemonic (state: string list, value: bool) = 
+            switchField "daemonic" value::state
+
+        /// List FQCN of extensions which shall be loaded at actor system startup.
+        /// Should be on the format: 'extensions = ["foo", "bar"]' etc.
+        /// See the Akka Documentation for more info about Extensions
+        [<CustomOperation("extensions");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Extensions (state: string list, x: string list) = 
+            quotedListField "extensions" x::state
+
+        /// Home directory of Akka, modules in the deploy directory will be loaded.
+        [<CustomOperation("home");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Home (state: string list, x: string) = 
+            field "home" x::state
+        
+        /// Log the complete configuration at INFO level when the actor system is started.
+        /// This is useful when you are uncertain of what configuration is used.
+        [<CustomOperation("log_config_on_start");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.LogConfigOnStart (state: string list, value: bool) = 
+            switchField "log-config-on-start" value::state
+
+        /// Log at info level when messages are sent to dead letters.
+        ///
+        /// Possible values:
+        ///
+        /// on: all dead letters are logged
+        ///
+        /// off: no logging of dead letters
+        ///
+        /// n: positive integer, number of dead letters that will be logged
+        [<CustomOperation("log_dead_letters");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.LogDeadLetters (state: string list, value: bool) = 
+            switchField "log-dead-letters" value::state
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.LogDeadLetters (state: string list, value) =
+            positiveField "log-dead-letters" value::state
+            
+        /// Possibility to turn off logging of dead letters while the actor system
+        /// is shutting down. Logging is only done when enabled by 'log-dead-letters'
+        /// setting.
+        [<CustomOperation("log_dead_letters_during_shutdown");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.LogDeadLettersDuringShutdown (state: string list, value: bool) =
+            switchField "log-dead-letters-during-shutdown" value::state
+
+        /// Possibility to turn off logging of dead letters while the actor system
+        /// is shutting down. Logging is only done when enabled by 'log-dead-letters'
+        /// setting.
+        [<CustomOperation("log_dead_letters_suspend_duration");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.LogDeadLettersSuspendDuration (state: string list, value: 'Duration) =
+            durationField "log-dead-letters-suspend-duration" value::state
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.LogDeadLettersSuspendDuration (state: string list, _: Hocon.Infinite) =
+            "log-dead-letters-suspend-duration = infinite"::state
+
+        /// You can enable asynchronous loggers creation by setting this to `true`.
+        /// This may be useful in cases when ActorSystem creation takes more time
+        /// then it should, or for whatever other reason
+        [<CustomOperation("logger_async_start");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.LoggerAsyncStart (state: string list, value: bool) =
+            boolField "logger-async-start" value::state
+
+        /// Loggers are created and registered synchronously during ActorSystem
+        /// start-up, and since they are actors, this timeout is used to bound the
+        /// waiting time
+        [<CustomOperation("logger_startup_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.LoggerStartupTimeout (state: string list, value: 'Duration) = 
+            durationField "logger-startup-timeout" value::state
+            
+        /// Loggers to register at boot time (akka.event.Logging$DefaultLogger logs to STDOUT)
+        [<CustomOperation("loggers");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Loggers (state: string list, x: string list) =
+            quotedListField "loggers" x::state
+
+        /// Specifies the default loggers dispatcher
+        [<CustomOperation("loggers_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.LoggersDispatcher (state: string list, x: string) = 
+            field "loggers-dispatcher" x::state
+
+        /// Log level used by the configured loggers (see "loggers") as soon
+        /// as they have been started; before that, see "stdout-loglevel"
+        ///
+        /// Options: OFF, ERROR, WARNING, INFO, DEBUG
+        [<CustomOperation("loglevel");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Loglevel (state: string list, loglevel: Hocon.LogLevel) = 
+            field "loglevel" loglevel.Text::state
+
+        /// Log level for the very basic logger activated during AkkaApplication startup
+        /// 
+        /// Options: OFF, ERROR, WARNING, INFO, DEBUG
+        [<CustomOperation("stdout_loglevel");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.StdoutLoglevel (state: string list, loglevel: Hocon.LogLevel) = 
+            field "stdout-loglevel" loglevel.Text::state
+
+        /// Akka version, checked against the runtime version of Akka.
+        [<CustomOperation("version");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Version (state: string list, major: int, minor: int, patch: int) = 
+            sprintf "version = %i.%i.%i Akka" major minor patch::state
+
+    let akka = AkkaBuilder()

--- a/src/Akkling.Hocon/Akkling.Hocon.fsproj
+++ b/src/Akkling.Hocon/Akkling.Hocon.fsproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>0.10.0</Version>
+    <Authors>Bartosz Sypytkowski</Authors>
+    <Description>Akka.NET HOCON computation expressions</Description>
+    <PackageProjectUrl>https://github.com/Horusiath/Akkling</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/Horusiath/Akkling/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageTags>akka.net fsharp hocon</PackageTags>
+    <PackageReleaseNotes>
+      * Upgraded Akka.NET dependencies to 1.4.2
+      * Consolidated supported .NET version to .NET Standard 2.0
+      * Removed PersistentView (as its no longer supported)
+      * Akkling.Streams: added support to stream refs, observables, cancellation tokens and withContext variants.
+      * Akkling.Streams: switched tuple args to value tuples to match Akka.Streams API.
+    </PackageReleaseNotes>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Types.fs" />
+    <Compile Include="Common.fs" />
+    <Compile Include="Shared.fs" />
+    <Compile Include="Shared.Debug.fs" />
+    <Compile Include="Actor.Typed.fs" />
+    <Compile Include="Actor.Inbox.fs" />
+    <Compile Include="Actor.Router.fs" />
+    <Compile Include="Actor.Dispatcher.fs" />
+    <Compile Include="Actor.DefaultMailbox.fs" />
+    <Compile Include="Actor.Mailbox.fs" />
+    <Compile Include="Actor.Serializers.fs" />
+    <Compile Include="IO.Pools.fs" />
+    <Compile Include="Remote.Protocols.fs" />
+    <Compile Include="Shared.Tcp.fs" />
+    <Compile Include="Shared.Udp.fs" />
+    <Compile Include="IO.Dns.fs" />
+    <Compile Include="IO.fs" />
+    <Compile Include="Cluster.Metrics.fs" />
+    <Compile Include="Cluster.PubSub.fs" />
+    <Compile Include="Cluster.Client.fs" />
+    <Compile Include="Cluster.Role.fs" />
+    <Compile Include="Cluster.FailureDetector.fs" />
+    <Compile Include="Cluster.SplitBrainResolver.fs" />
+    <Compile Include="Cluster.Singleton.fs" />
+    <Compile Include="Shared.Cluster.fs" />
+    <Compile Include="Actor.Deployment.fs" />
+    <Compile Include="Actor.fs" />
+    <Compile Include="Remote.TransportFailureDetector.fs" />
+    <Compile Include="Remote.WatchFailureDetector.fs" />
+    <Compile Include="Remote.Gremlin.fs" />
+    <Compile Include="Remote.DotNetty.fs" />
+    <Compile Include="Remote.fs" />
+    <Compile Include="Scheduler.fs" />
+    <Compile Include="CoordinatedShutdown.fs" />
+    <Compile Include="Persistence.FSM.fs" />
+    <Compile Include="Persistence.AtLeastOnceDelivery.fs" />
+    <Compile Include="Persistence.View.fs" />
+    <Compile Include="Persistence.Plugin.fs" />
+    <Compile Include="Persistence.Proxy.fs" />
+    <Compile Include="Persistence.PluginFallback.fs" />
+    <Compile Include="Persistence.Journal.fs" />
+    <Compile Include="Persistence.SnapshotStore.fs" />
+    <Compile Include="Persistence.fs" />
+    <Compile Include="Streams.fs" />
+    <Compile Include="Test.fs" />
+    <Compile Include="Akka.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.7.0" />
+  </ItemGroup>
+</Project>

--- a/src/Akkling.Hocon/Cluster.Client.fs
+++ b/src/Akkling.Hocon/Cluster.Client.fs
@@ -1,0 +1,244 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Client =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type ReceptionistBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        /// Actor name of the ClusterReceptionist actor, /system/receptionist
+        [<CustomOperation("name");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Name (state: string list, x: string) =
+            field "name" x::state
+        /// Actor name of the ClusterReceptionist actor, /system/receptionist
+        member this.name value =
+            this.Name([], value)
+            |> this.Run
+    
+        /// Start the receptionist on members tagged with this role.
+        /// All members are used if undefined or empty.
+        [<CustomOperation("role");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Role (state: string list, x: string) =
+            field "role" x::state
+        /// Start the receptionist on members tagged with this role.
+        /// All members are used if undefined or empty.
+        member this.role value =
+            this.Role([], value)
+            |> this.Run
+        
+        /// The receptionist will send this number of contact points to the client
+        [<CustomOperation("number_of_contacts");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.NumberOfContacts (state: string list, value: int) =
+            positiveField "number-of-contacts" value::state
+        /// The receptionist will send this number of contact points to the client
+        member this.number_of_contacts value =
+            this.NumberOfContacts([], value)
+            |> this.Run
+        
+        /// The actor that tunnel response messages to the client will be stopped
+        /// after this time of inactivity.
+        [<CustomOperation("response_tunnel_receive_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ResponseTunnelReceiveTimeout (state: string list, value: 'Duration) =
+            durationField "response-tunnel-receive-timeout" value::state
+        /// The actor that tunnel response messages to the client will be stopped
+        /// after this time of inactivity.
+        member inline this.response_tunnel_receive_timeout (value: 'Duration) =
+            this.ResponseTunnelReceiveTimeout([], value)
+            |> this.Run
+        
+        /// The id of the dispatcher to use for ClusterReceptionist actors. 
+        /// If not specified, the internal dispatcher is used.
+        /// If specified you need to define the settings of the actual dispatcher.
+        [<CustomOperation("use_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.UseDispatcher (state: string list, x: string) =
+            quotedField "use-dispatcher" x::state
+        /// The id of the dispatcher to use for ClusterReceptionist actors. 
+        /// If not specified, the internal dispatcher is used.
+        /// If specified you need to define the settings of the actual dispatcher.
+        member this.use_dispatcher value =
+            this.UseDispatcher([], value)
+            |> this.Run
+        
+        /// How often failure detection heartbeat messages should be received for
+        /// each ClusterClient
+        [<CustomOperation("heartbeat_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.HeartbeatInterval (state: string list, value: 'Duration) =
+            durationField "heartbeat-interval" value::state
+        /// How often failure detection heartbeat messages should be received for
+        /// each ClusterClient
+        member inline this.heartbeat_interval (value: 'Duration) =
+            this.HeartbeatInterval([], value)
+            |> this.Run
+        
+        /// Number of potentially lost/delayed heartbeats that will be
+        /// accepted before considering it to be an anomaly.
+        /// The ClusterReceptionist is using the akka.remote.DeadlineFailureDetector, which
+        /// will trigger if there are no heartbeats within the duration
+        /// heartbeat-interval + acceptable-heartbeat-pause, i.e. 15 seconds with
+        /// the default settings.
+        [<CustomOperation("acceptable_heartbeat_pause");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.AcceptableHeartbeatPause (state: string list, value: 'Duration) =
+            durationField "acceptable-heartbeat-pause" value::state
+        /// Number of potentially lost/delayed heartbeats that will be
+        /// accepted before considering it to be an anomaly.
+        /// The ClusterReceptionist is using the akka.remote.DeadlineFailureDetector, which
+        /// will trigger if there are no heartbeats within the duration
+        /// heartbeat-interval + acceptable-heartbeat-pause, i.e. 15 seconds with
+        /// the default settings.
+        member inline this.acceptable_heartbeat_pause (value: 'Duration) =
+            this.AcceptableHeartbeatPause([], value)
+            |> this.Run
+        
+        /// Failure detection checking interval for checking all ClusterClients
+        [<CustomOperation("failure_detection_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.FailureDetectionInterval (state: string list, value: 'Duration) =
+            durationField "failure-detection-interval" value::state
+        /// Failure detection checking interval for checking all ClusterClients
+        member inline this.failure_detection_interval (value: 'Duration) =
+            this.FailureDetectionInterval([], value)
+            |> this.Run
+        
+    /// Settings for the ClusterClientReceptionist extension
+    let receptionist =
+        { new ReceptionistBuilder<Akka.Cluster.Client.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "receptionist" 4 state
+                |> Akka.Cluster.Client.Field }
+
+    [<AbstractClass>]
+    type ClientBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Cluster.Client.Field) = [x.ToString()]
+
+        /// Actor paths of the ClusterReceptionist actors on the servers (cluster nodes)
+        /// that the client will try to contact initially. It is mandatory to specify
+        /// at least one initial contact. 
+        ///
+        /// Comma separated full actor paths defined by a string on the form of
+        /// "akka.tcp://system@hostname:port/system/receptionist"
+        [<CustomOperation("initial_contacts");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.InitialContacts (state: string list, xs: string list) =
+            xs |> List.map System.Uri |> ignore
+            quotedListField "initial-contacts" xs::state
+        /// Actor paths of the ClusterReceptionist actors on the servers (cluster nodes)
+        /// that the client will try to contact initially. It is mandatory to specify
+        /// at least one initial contact. 
+        ///
+        /// Comma separated full actor paths defined by a string on the form of
+        /// "akka.tcp://system@hostname:port/system/receptionist"
+        member this.initial_contacts value =
+            this.InitialContacts([], value)
+            |> this.Run
+        
+        /// Interval at which the client retries to establish contact with one of 
+        /// ClusterReceptionist on the servers (cluster nodes)
+        [<CustomOperation("establishing_get_contacts_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.EstablishingGetContactsInterval (state: string list, value: 'Duration) =
+            durationField "establishing-get-contacts-interval" value::state
+        /// Interval at which the client retries to establish contact with one of 
+        /// ClusterReceptionist on the servers (cluster nodes)
+        member inline this.establishing_get_contacts_interval (value: 'Duration) =
+            this.EstablishingGetContactsInterval([], value)
+            |> this.Run
+        
+        /// Interval at which the client will ask the ClusterReceptionist for
+        /// new contact points to be used for next reconnect.
+        [<CustomOperation("refresh_contacts_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.RefreshContactsInterval (state: string list, value: 'Duration) =
+            durationField "refresh-contacts-interval" value::state
+        /// Interval at which the client will ask the ClusterReceptionist for
+        /// new contact points to be used for next reconnect.
+        member inline this.refresh_contacts_interval (value: 'Duration) =
+            this.RefreshContactsInterval([], value)
+            |> this.Run
+        
+        /// How often failure detection heartbeat messages should be sent
+        [<CustomOperation("heartbeat_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.HeartbeatInterval (state: string list, value: 'Duration) =
+            durationField "heartbeat-interval" value::state
+        /// How often failure detection heartbeat messages should be sent
+        member inline this.heartbeat_interval (value: 'Duration) =
+            this.HeartbeatInterval([], value)
+            |> this.Run
+        
+        /// Number of potentially lost/delayed heartbeats that will be
+        /// accepted before considering it to be an anomaly.
+        ///
+        /// The ClusterClient is using the akka.remote.DeadlineFailureDetector, which
+        /// will trigger if there are no heartbeats within the duration 
+        /// heartbeat-interval + acceptable-heartbeat-pause, i.e. 15 seconds with
+        /// the default settings.
+        [<CustomOperation("acceptable_heartbeat_pause");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.AcceptableHeartbeatPause (state: string list, value: 'Duration) =
+            durationField "acceptable-heartbeat-pause" value::state
+        /// Number of potentially lost/delayed heartbeats that will be
+        /// accepted before considering it to be an anomaly.
+        ///
+        /// The ClusterClient is using the akka.remote.DeadlineFailureDetector, which
+        /// will trigger if there are no heartbeats within the duration 
+        /// heartbeat-interval + acceptable-heartbeat-pause, i.e. 15 seconds with
+        /// the default settings.
+        member inline this.acceptable_heartbeat_pause (value: 'Duration) =
+            this.AcceptableHeartbeatPause([], value)
+            |> this.Run
+        
+        /// If connection to the receptionist is not established the client will buffer
+        /// this number of messages and deliver them the connection is established.
+        ///
+        /// When the buffer is full old messages will be dropped when new messages are sent
+        /// via the client. Use 0 to disable buffering, i.e. messages will be dropped
+        /// immediately if the location of the singleton is unknown.
+        ///
+        /// Maximum allowed buffer size is 10000.
+        [<CustomOperation("buffer_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.BufferSize (state: string list, value: int) =
+            if value < 10000 then
+                positiveField "buffer-size" value::state
+            else failwithf "buffer-size must be value less than 10000, was given: %i" value
+        /// If connection to the receptionist is not established the client will buffer
+        /// this number of messages and deliver them the connection is established.
+        ///
+        /// When the buffer is full old messages will be dropped when new messages are sent
+        /// via the client. Use 0 to disable buffering, i.e. messages will be dropped
+        /// immediately if the location of the singleton is unknown.
+        ///
+        /// Maximum allowed buffer size is 10000.
+        member this.buffer_size value =
+            this.BufferSize([], value)
+            |> this.Run
+        
+        /// If connection to the receiptionist is lost and the client has not been
+        /// able to acquire a new connection for this long the client will stop itself.
+        /// This duration makes it possible to watch the cluster client and react on a more permanent
+        /// loss of connection with the cluster, for example by accessing some kind of
+        /// service registry for an updated set of initial contacts to start a new cluster client with.
+        ///
+        /// If this is not wanted it can be set to "off" to disable the timeout and retry
+        /// forever.
+        [<CustomOperation("reconnect_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ReconnectTimeout (state: string list, value: bool) = 
+            switchField "reconnect-timeout" value::state
+        /// If connection to the receiptionist is lost and the client has not been
+        /// able to acquire a new connection for this long the client will stop itself.
+        /// This duration makes it possible to watch the cluster client and react on a more permanent
+        /// loss of connection with the cluster, for example by accessing some kind of
+        /// service registry for an updated set of initial contacts to start a new cluster client with.
+        ///
+        /// If this is not wanted it can be set to "off" to disable the timeout and retry
+        /// forever.
+        member this.reconnect_timeout value =
+            this.ReconnectTimeout([], value)
+            |> this.Run
+        
+    /// Settings for the ClusterClient
+    let client =
+        { new ClientBuilder<Akka.Cluster.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "client" 3 state
+                |> Akka.Cluster.Field }

--- a/src/Akkling.Hocon/Cluster.FailureDetector.fs
+++ b/src/Akkling.Hocon/Cluster.FailureDetector.fs
@@ -1,0 +1,128 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module FailureDetector =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type FailureDetectorBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        /// FQCN of the failure detector implementation.
+        /// It must implement akka.remote.FailureDetector and have
+        /// a public constructor with a com.typesafe.config.Config and
+        /// akka.actor.EventStream parameter.
+        [<CustomOperation("implementation_class");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ImplementationClass (state: string list, x: string) = 
+            quotedField "implementation-class" x::state
+        /// FQCN of the failure detector implementation.
+        /// It must implement akka.remote.FailureDetector and have
+        /// a public constructor with a com.typesafe.config.Config and
+        /// akka.actor.EventStream parameter.
+        member this.implementation_class value =
+            this.ImplementationClass([], value)
+            |> this.Run
+        
+        /// How often keep-alive heartbeat messages should be sent to each connection.
+        [<CustomOperation("heartbeat_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.HeartbeatInterval (state: string list, value: 'Duration) =
+            durationField "heartbeat-interval" value::state
+        /// How often keep-alive heartbeat messages should be sent to each connection.
+        member inline this.heartbeat_interval (value: 'Duration) =
+            this.HeartbeatInterval([], value)
+            |> this.Run
+        
+        /// Defines the failure detector threshold.
+        /// A low threshold is prone to generate many wrong suspicions but ensures
+        /// a quick detection in the event of a real crash. Conversely, a high
+        /// threshold generates fewer mistakes but needs more time to detect
+        /// actual crashes.
+        [<CustomOperation("threshold");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.Threshold (state: string list, x) = 
+            positiveFieldf "threshold" x::state
+        /// Defines the failure detector threshold.
+        /// A low threshold is prone to generate many wrong suspicions but ensures
+        /// a quick detection in the event of a real crash. Conversely, a high
+        /// threshold generates fewer mistakes but needs more time to detect
+        /// actual crashes.
+        member inline this.threshold value =
+            this.Threshold([], value)
+            |> this.Run
+            
+        /// Number of the samples of inter-heartbeat arrival times to adaptively
+        /// calculate the failure timeout for connections.
+        [<CustomOperation("max_sample_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.MaxSampleSize (state: string list, x) = 
+            positiveField "max-sample-size" x::state
+        /// Number of the samples of inter-heartbeat arrival times to adaptively
+        /// calculate the failure timeout for connections.
+        member inline this.max_sample_size value =
+            this.MaxSampleSize([], value)
+            |> this.Run
+            
+        /// Minimum standard deviation to use for the normal distribution in
+        /// AccrualFailureDetector. Too low standard deviation might result in
+        /// too much sensitivity for sudden, but normal, deviations in heartbeat
+        /// inter arrival times.
+        [<CustomOperation("min_std_deviation");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.MinStdDeviation (state: string list, value: 'Duration) =
+            durationField "min-std-deviation" value::state
+        /// Minimum standard deviation to use for the normal distribution in
+        /// AccrualFailureDetector. Too low standard deviation might result in
+        /// too much sensitivity for sudden, but normal, deviations in heartbeat
+        /// inter arrival times.
+        member inline this.min_std_deviation (value: 'Duration) =
+            this.MinStdDeviation([], value)
+            |> this.Run
+        
+        /// Number of potentially lost/delayed heartbeats that will be
+        /// accepted before considering it to be an anomaly.
+        /// This margin is important to be able to survive sudden, occasional,
+        /// pauses in heartbeat arrivals, due to for example garbage collect or
+        /// network drop.
+        [<CustomOperation("acceptable_heartbeat_pause");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.AcceptableHeartbeatPause (state: string list, value: 'Duration) =
+            durationField "acceptable-heartbeat-pause" value::state
+        /// Number of potentially lost/delayed heartbeats that will be
+        /// accepted before considering it to be an anomaly.
+        /// This margin is important to be able to survive sudden, occasional,
+        /// pauses in heartbeat arrivals, due to for example garbage collect or
+        /// network drop.
+        member inline this.acceptable_heartbeat_pause (value: 'Duration) =
+            this.AcceptableHeartbeatPause([], value)
+            |> this.Run
+        
+        /// Number of member nodes that each member will send heartbeat messages to,
+        /// i.e. each node will be monitored by this number of other nodes.
+        [<CustomOperation("monitored_by_nr_of_members");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MonitoredByNrOfMembers (state: string list, value: int) =
+            positiveField "monitored-by-nr-of-members" value::state
+        /// Number of member nodes that each member will send heartbeat messages to,
+        /// i.e. each node will be monitored by this number of other nodes.
+        member this.monitored_by_nr_of_members value =
+            this.MonitoredByNrOfMembers([], value)
+            |> this.Run
+        
+        /// After the heartbeat request has been sent the first failure detection
+        /// will start after this period, even though no heartbeat mesage has
+        /// been received.
+        [<CustomOperation("expected_response_after");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ExpectedResponseAfter (state: string list, value: 'Duration) =
+            durationField "expected-response-after" value::state
+        /// After the heartbeat request has been sent the first failure detection
+        /// will start after this period, even though no heartbeat mesage has
+        /// been received.
+        member inline this.expected_response_after (value: 'Duration) =
+            this.ExpectedResponseAfter([], value)
+            |> this.Run
+            
+    /// Settings for the Phi accrual failure detector (http://ddg.jaist.ac.jp/pub/HDY+04.pdf
+    /// [Hayashibara et al]) used by the cluster subsystem to detect unreachable
+    /// members.
+    let failure_detector =
+        { new FailureDetectorBuilder<Akka.Cluster.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "failure-detector" 3 state
+                |> Akka.Cluster.Field }

--- a/src/Akkling.Hocon/Cluster.Metrics.fs
+++ b/src/Akkling.Hocon/Cluster.Metrics.fs
@@ -1,0 +1,145 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Metrics =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+    
+    /// Supervision strategy.
+    [<AbstractClass>]
+    type ConfigurationBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        /// Log restart attempts.
+        [<CustomOperation("loggingEnabled");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.LoggingEnabled (state: string list, value: bool) = 
+            switchField "loggingEnabled" value::state
+        /// Log restart attempts.
+        member this.loggingEnabled value =
+            this.LoggingEnabled([], value)
+            |> this.Run
+        
+        /// Child actor restart-on-failure window.
+        [<CustomOperation("within_time_range");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.WithinTimeRange (state: string list, value: 'Duration) =
+            durationField "withinTimeRange" value::state
+        /// Child actor restart-on-failure window.
+        member inline this.within_time_range (value: 'Duration) =
+            this.WithinTimeRange([], value)
+            |> this.Run
+        
+        /// Maximum number of restart attempts before child actor is stopped.
+        [<CustomOperation("max_nr_of_retries");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MaxNrOfRetries (state: string list, value: int) =
+            positiveField "maxNrOfRetries" value::state
+        /// Maximum number of restart attempts before child actor is stopped.
+        member this.max_nr_of_retries value =
+            this.MaxNrOfRetries([], value)
+            |> this.Run
+        
+    /// Supervision strategy.
+    let configuration =
+        { new ConfigurationBuilder<Akka.Cluster.Strategy.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "configuration" 6 state
+                |> Akka.Cluster.Strategy.Field }
+
+    /// Supervision strategy.
+    [<AbstractClass>]
+    type StrategyBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Cluster.Strategy.Field) = [x.ToString()]
+        
+        /// FQCN of class providing `akka.actor.SupervisorStrategy`.
+        /// Must have a constructor with signature `<init>(com.typesafe.config.Config)`.
+        /// Default metrics strategy provider is a configurable extension of `OneForOneStrategy`.
+        [<CustomOperation("provider");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Provider (state: string list, x: string) = 
+            quotedField "provider" x::state
+        /// FQCN of class providing `akka.actor.SupervisorStrategy`.
+        /// Must have a constructor with signature `<init>(com.typesafe.config.Config)`.
+        /// Default metrics strategy provider is a configurable extension of `OneForOneStrategy`.
+        member this.provider value =
+            this.Provider([], value)
+            |> this.Run
+        
+    /// Supervision strategy.
+    let strategy =
+        { new StrategyBuilder<Akka.Cluster.Supervisor.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "strategy" 5 state
+                |> Akka.Cluster.Supervisor.Field }
+
+    /// Metrics supervisor actor.
+    [<AbstractClass>]
+    type SupervisorBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Cluster.Supervisor.Field) = [x.ToString()]
+        
+        /// Actor name of the mediator actor, 
+        ///
+        /// Default: /system/distributedPubSubMediator
+        [<CustomOperation("name");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Name (state: string list, x: string) = 
+            field "name" x::state
+        /// Actor name of the mediator actor, 
+        ///
+        /// Default: /system/distributedPubSubMediator
+        member this.name value =
+            this.Name([], value)
+            |> this.Run
+        
+    /// Metrics supervisor actor.
+    let supervisor =
+        { new SupervisorBuilder<Akka.Cluster.Metrics.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "supervisor" 4 state
+                |> Akka.Cluster.Metrics.Field }
+
+    /// Cluster metrics extension.
+    ///
+    /// Provides periodic statistics collection and publication throughout the cluster.
+    [<AbstractClass>]
+    type MetricsBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Cluster.Metrics.Field) = [x.ToString()]
+        
+        /// The id of the dispatcher to use for this actor.
+        /// If undefined or empty the dispatcher specified in code
+        /// (Props.withDispatcher) is used, or default-dispatcher if not
+        /// specified at all.
+        [<CustomOperation("dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Dispatcher (state: string list, value: string) =
+            quotedField "dispatcher" value::state
+        /// The id of the dispatcher to use for this actor.
+        /// If undefined or empty the dispatcher specified in code
+        /// (Props.withDispatcher) is used, or default-dispatcher if not
+        /// specified at all.
+        member this.dispatcher value =
+            this.Dispatcher([], value)
+            |> this.Run
+            
+        /// How often keep-alive heartbeat messages should be sent to each connection.
+        [<CustomOperation("periodic_tasks_initial_delay");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.PeriodicTasksInitialDelay (state: string list, value: 'Duration) =
+            durationField "periodic-tasks-initial-delay" value::state
+        /// How often keep-alive heartbeat messages should be sent to each connection.
+        member inline this.periodic_tasks_initial_delay (value: 'Duration) =
+            this.PeriodicTasksInitialDelay([], value)
+            |> this.Run
+        
+    /// Cluster metrics extension.
+    ///
+    /// Provides periodic statistics collection and publication throughout the cluster.
+    let metrics =
+        { new MetricsBuilder<Akka.Cluster.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "metrics" 3 state
+                |> Akka.Cluster.Field }

--- a/src/Akkling.Hocon/Cluster.PubSub.fs
+++ b/src/Akkling.Hocon/Cluster.PubSub.fs
@@ -1,0 +1,96 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module PubSub =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    /// Settings for the DistributedPubSub extension
+    [<AbstractClass>]
+    type PubSubBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        /// Actor name of the mediator actor, 
+        ///
+        /// Default: /system/distributedPubSubMediator
+        [<CustomOperation("name");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Name (state: string list, x: string) = 
+            field "name" x::state
+        /// Actor name of the mediator actor, 
+        ///
+        /// Default: /system/distributedPubSubMediator
+        member this.name value =
+            this.Name([], value)
+            |> this.Run
+        
+        /// Start the mediator on members tagged with this role.
+        /// All members are used if undefined or empty.
+        [<CustomOperation("role");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Role (state: string list, x: string) = 
+            field "role" x::state
+        /// Start the mediator on members tagged with this role.
+        /// All members are used if undefined or empty.
+        member this.role value =
+            this.Role([], value)
+            |> this.Run
+        
+        /// The routing logic to use for 'Send'
+        /// Possible values: random, round-robin, broadcast
+        [<CustomOperation("routing_logic");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.RoutingLogic (state: string list, x: Hocon.Router.Logic) = 
+            field "routing-logic" (x.Text)::state
+        /// The routing logic to use for 'Send'
+        /// Possible values: random, round-robin, broadcast
+        member this.routing_logic value =
+            this.RoutingLogic([], value)
+            |> this.Run
+        
+        /// How often keep-alive heartbeat messages should be sent to each connection.
+        [<CustomOperation("gossip_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.GossipInterval (state: string list, value: 'Duration) =
+            durationField "gossip-interval" value::state
+        /// How often keep-alive heartbeat messages should be sent to each connection.
+        member inline this.gossip_interval (value: 'Duration) =
+            this.GossipInterval([], value)
+            |> this.Run
+        
+        /// Removed entries are pruned after this duration
+        [<CustomOperation("removed_time_to_live");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.RemovedTimeToLive (state: string list, value: 'Duration) =
+            durationField "removed-time-to-live" value::state
+        /// Removed entries are pruned after this duration
+        member inline this.removed_time_to_live (value: 'Duration) =
+            this.RemovedTimeToLive([], value)
+            |> this.Run
+        
+        /// Maximum number of elements to transfer in one message when synchronizing the registries.
+        /// Next chunk will be transferred in next round of gossip.
+        [<CustomOperation("max_delta_elements");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MaxDeltaElements (state: string list, value: int) =
+            positiveField "max-delta-elements" value::state
+        /// Maximum number of elements to transfer in one message when synchronizing the registries.
+        /// Next chunk will be transferred in next round of gossip.
+        member this.max_delta_elements value =
+            this.MaxDeltaElements([], value)
+            |> this.Run
+        
+        /// The id of the dispatcher to use for DistributedPubSubMediator actors. 
+        /// If not specified default dispatcher is used.
+        /// If specified you need to define the settings of the actual dispatcher.
+        [<CustomOperation("use_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.UseDispatcher (state: string list, x: string) = 
+            quotedField "use-dispatcher" x::state
+        /// The id of the dispatcher to use for DistributedPubSubMediator actors. 
+        /// If not specified default dispatcher is used.
+        /// If specified you need to define the settings of the actual dispatcher.
+        member this.use_dispatcher value =
+            this.UseDispatcher([], value)
+            |> this.Run
+        
+    /// Settings for the DistributedPubSub extension
+    let pub_sub =
+        { new PubSubBuilder<Akka.Cluster.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "pub-sub" 3 state
+                |> Akka.Cluster.Field }

--- a/src/Akkling.Hocon/Cluster.Role.fs
+++ b/src/Akkling.Hocon/Cluster.Role.fs
@@ -1,0 +1,44 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Role =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+        
+    [<AbstractClass>]
+    type RoleBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        /// Minimum required number of members of a certain role before the leader
+        /// changes member status of 'Joining' members to 'Up'. Typically used together
+        /// with 'Cluster.registerOnMemberUp' to defer some action, such as starting
+        /// actors, until the cluster has reached a certain size.
+        ///
+        /// E.g. to require 2 nodes with role 'frontend' and 3 nodes with role 'backend':
+        ///   frontend.min-nr-of-members = 2
+        ///   backend.min-nr-of-members = 3
+        ///
+        /// You can apply multiples of thie field.
+        [<CustomOperation("min_nr_of_members");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MinNrOfMembers (state: string list, role: string, number: int) =
+            positiveField (sprintf "%s.min-nr-of-members" role) number::state
+        /// Minimum required number of members of a certain role before the leader
+        /// changes member status of 'Joining' members to 'Up'. Typically used together
+        /// with 'Cluster.registerOnMemberUp' to defer some action, such as starting
+        /// actors, until the cluster has reached a certain size.
+        ///
+        /// E.g. to require 2 nodes with role 'frontend' and 3 nodes with role 'backend':
+        ///   frontend.min-nr-of-members = 2
+        ///   backend.min-nr-of-members = 3
+        ///
+        /// You can apply multiples of thie field.
+        member this.min_nr_of_members role number =
+            this.MinNrOfMembers([], role, number)
+            |> this.Run
+
+    let role =
+        { new RoleBuilder<Akka.Cluster.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "role" 3 state
+                |> Akka.Cluster.Field }

--- a/src/Akkling.Hocon/Cluster.Singleton.fs
+++ b/src/Akkling.Hocon/Cluster.Singleton.fs
@@ -1,0 +1,138 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module ClusterSingleton =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+    
+    [<AbstractClass>]
+    type SingletonProxyBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        member _.Yield (x: Akka.Cluster.SplitBrainResolver.Field) = [x.ToString()]
+        
+        /// The actor name of the singleton actor that is started by the ClusterSingletonManager
+        [<CustomOperation("singleton_name");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SingletonName (state: string list, x: string) =
+            quotedField "singleton-name" x::state
+        /// The actor name of the singleton actor that is started by the ClusterSingletonManager
+        member this.singleton_name value =
+            this.SingletonName([], value)
+            |> this.Run
+        
+        /// The role of the cluster nodes where the singleton can be deployed. 
+        /// If the role is not specified then any node will do.
+        [<CustomOperation("role");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Role (state: string list, x: string) =
+            field "role" x::state
+        /// The role of the cluster nodes where the singleton can be deployed. 
+        /// If the role is not specified then any node will do.
+        member this.role value =
+            this.Role([], value)
+            |> this.Run
+        
+        /// Interval at which the proxy will try to resolve the singleton instance.
+        [<CustomOperation("singleton_identification_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.SingletonIdentificationInterval (state: string list, value: 'Duration) =
+            durationField "singleton-identification-interval" value::state
+        /// Interval at which the proxy will try to resolve the singleton instance.
+        member inline this.singleton_identification_interval (value: 'Duration) =
+            this.SingletonIdentificationInterval([], value)
+            |> this.Run
+        
+        /// If the location of the singleton is unknown the proxy will buffer this
+        /// number of messages and deliver them when the singleton is identified. 
+        /// When the buffer is full old messages will be dropped when new messages are
+        /// sent via the proxy.
+        ///
+        /// Use 0 to disable buffering, i.e. messages will be dropped immediately if
+        /// the location of the singleton is unknown.
+        ///
+        /// Maximum allowed buffer size is 10000.
+        [<CustomOperation("buffer_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.BufferSize (state: string list, value: int) =
+            let fieldName = "buffer-size"
+            
+            if value > 10000 then 
+                failwithf "Field %s must have a value between 0 and 10000. You provided: %i" 
+                    fieldName value
+            else positiveField fieldName value::state
+        /// If the location of the singleton is unknown the proxy will buffer this
+        /// number of messages and deliver them when the singleton is identified. 
+        /// When the buffer is full old messages will be dropped when new messages are
+        /// sent via the proxy.
+        ///
+        /// Use 0 to disable buffering, i.e. messages will be dropped immediately if
+        /// the location of the singleton is unknown.
+        ///
+        /// Maximum allowed buffer size is 10000.
+        member this.buffer_size value =
+            this.BufferSize([], value)
+            |> this.Run
+            
+    let singleton_proxy =
+        { new SingletonProxyBuilder<Akka.Cluster.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "singleton-proxy" 3 state
+                |> Akka.Cluster.Field }
+    
+    [<AbstractClass>]
+    type SingletonBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        /// The actor name of the child singleton actor.
+        [<CustomOperation("singleton_name");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SingletonName (state: string list, x: string) =
+            quotedField "singleton-name" x::state
+        /// The actor name of the child singleton actor.
+        member this.singleton_name value =
+            this.SingletonName([], value)
+            |> this.Run
+        
+        /// Singleton among the nodes tagged with specified role.
+        ///
+        /// If the role is not specified it's a singleton among all nodes in the cluster.
+        [<CustomOperation("role");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Role (state: string list, x: string) =
+            field "role" x::state
+        /// Singleton among the nodes tagged with specified role.
+        ///
+        /// If the role is not specified it's a singleton among all nodes in the cluster.
+        member this.role value =
+            this.Role([], value)
+            |> this.Run
+        
+        /// When a node is becoming oldest it sends hand-over request to previous oldest, 
+        /// that might be leaving the cluster. This is retried with this interval until 
+        /// the previous oldest confirms that the hand over has started or the previous 
+        /// oldest member is removed from the cluster (+ akka.cluster.down-removal-margin).
+        [<CustomOperation("hand_over_retry_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.HandOverRetryInterval (state: string list, value: 'Duration) =
+            durationField "hand-over-retry-interval" value::state
+        /// When a node is becoming oldest it sends hand-over request to previous oldest, 
+        /// that might be leaving the cluster. This is retried with this interval until 
+        /// the previous oldest confirms that the hand over has started or the previous 
+        /// oldest member is removed from the cluster (+ akka.cluster.down-removal-margin).
+        member inline this.hand_over_retry_interval (value: 'Duration) =
+            this.HandOverRetryInterval([], value)
+            |> this.Run
+        
+        /// The number of retries are derived from hand-over-retry-interval and
+        /// akka.cluster.down-removal-margin (or ClusterSingletonManagerSettings.RemovalMargin),
+        /// but it will never be less than this property.
+        [<CustomOperation("min_number_of_hand_over_retries");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MinNumberOfHandOverRetries (state: string list, value: int) =
+            positiveField "min-number-of-hand-over-retries" value::state
+        /// The number of retries are derived from hand-over-retry-interval and
+        /// akka.cluster.down-removal-margin (or ClusterSingletonManagerSettings.RemovalMargin),
+        /// but it will never be less than this property.
+        member this.min_number_of_hand_over_retries value =
+            this.MinNumberOfHandOverRetries([], value)
+            |> this.Run
+            
+    let singleton =
+        { new SingletonBuilder<Akka.Cluster.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "singleton" 3 state
+                |> Akka.Cluster.Field }

--- a/src/Akkling.Hocon/Cluster.SplitBrainResolver.fs
+++ b/src/Akkling.Hocon/Cluster.SplitBrainResolver.fs
@@ -1,0 +1,154 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module SplitBrainResolver =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+    
+    [<AbstractClass>]
+    type KeepMajorityBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        /// If the 'role' is defined the decision is based only on members with that 'role'
+        [<CustomOperation("role");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Role (state: string list, x: string) =
+            field "role" x::state
+        /// If the 'role' is defined the decision is based only on members with that 'role'
+        member this.role value =
+            this.Role([], value)
+            |> this.Run
+
+    let keep_majority =
+        { new KeepMajorityBuilder<Akka.Cluster.SplitBrainResolver.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "keep-majority" 4 state
+                |> Akka.Cluster.SplitBrainResolver.Field }
+    
+    [<AbstractClass>]
+    type KeepOldestBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        /// Enable downing of the oldest node when it is partitioned from all other nodes
+        [<CustomOperation("down_if_alone");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.DownIfAlone (state: string list, value: bool) = 
+            switchField "down-if-alone" value::state
+        /// Enable downing of the oldest node when it is partitioned from all other nodes
+        member this.down_if_alone value =
+            this.DownIfAlone([], value)
+            |> this.Run
+            
+        /// if the 'role' is defined the decision is based only on members with that 'role',
+        /// i.e. using the oldest member (singleton) within the nodes with that role
+        [<CustomOperation("role");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Role (state: string list, x: string) =
+            field "role" x::state
+        /// if the 'role' is defined the decision is based only on members with that 'role',
+        /// i.e. using the oldest member (singleton) within the nodes with that role
+        member this.role value =
+            this.Role([], value)
+            |> this.Run
+
+    let keep_oldest =
+        { new KeepOldestBuilder<Akka.Cluster.SplitBrainResolver.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "keep-majority" 4 state
+                |> Akka.Cluster.SplitBrainResolver.Field }
+    
+    [<AbstractClass>]
+    type KeepRefereeBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        /// Referee address on the form of "akka.tcp://system@hostname:port"
+        [<CustomOperation("address");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Address (state: string list, x: string) =
+            if isNull x || x <> "" then System.Uri(x) |> ignore
+            quotedField "address" x::state
+        /// Referee address on the form of "akka.tcp://system@hostname:port"
+        member this.address value =
+            this.Address([], value)
+            |> this.Run
+            
+        [<CustomOperation("down_all_if_less_than_nodes");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.DownAllIfLessThanNodes (state: string list, value: int) =
+            positiveField "down-all-if-less-than-nodes" value::state
+        member this.down_all_if_less_than_nodes value =
+            this.DownAllIfLessThanNodes([], value)
+            |> this.Run
+
+    let keep_referee =
+        { new KeepRefereeBuilder<Akka.Cluster.SplitBrainResolver.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "keep-referee" 4 state
+                |> Akka.Cluster.SplitBrainResolver.Field }
+    
+    [<AbstractClass>]
+    type StaticQuorumBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        /// Minimum number of nodes that the cluster must have
+        [<CustomOperation("quorum_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.QuorumSize (state: string list, value: int) =
+            positiveField "quorum-size" value::state
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member this.QuorumSize (state: string list, value: int option) =
+            match value with
+            | Some i -> this.QuorumSize(state, i)
+            | None -> field "quorum-size" "undefined"::state
+        /// Minimum number of nodes that the cluster must have
+        member this.quorum_size (value: int) =
+            this.QuorumSize([], value)
+            |> this.Run
+        /// Minimum number of nodes that the cluster must have
+        member this.quorum_size (value: int option) =
+            this.QuorumSize([], value)
+            |> this.Run
+
+        /// If the 'role' is defined the decision is based only on members with that 'role'
+        [<CustomOperation("role");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Role (state: string list, x: string) =
+            field "role" x::state
+        /// If the 'role' is defined the decision is based only on members with that 'role'
+        member this.role value =
+            this.Role([], value)
+            |> this.Run
+
+    let static_quorum =
+        { new StaticQuorumBuilder<Akka.Cluster.SplitBrainResolver.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "static-quorum" 4 state
+                |> Akka.Cluster.SplitBrainResolver.Field }
+    
+    [<AbstractClass>]
+    type SplitBrainResolverBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        member _.Yield (x: Akka.Cluster.SplitBrainResolver.Field) = [x.ToString()]
+        
+        /// Enable one of the available strategies (see descriptions below):
+        /// static-quorum, keep-majority, keep-oldest, keep-referee
+        [<CustomOperation("active_strategy");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ActiveStrategy (state: string list, value: bool) = 
+            switchField "active-strategy" value::state
+        /// Enable one of the available strategies (see descriptions below):
+        /// static-quorum, keep-majority, keep-oldest, keep-referee
+        member this.active_strategy value =
+            this.ActiveStrategy([], value)
+            |> this.Run
+        
+        /// Decision is taken by the strategy when there has been no membership or
+        /// reachability changes for this duration, i.e. the cluster state is stable.
+        [<CustomOperation("stable_after");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.StableAfter (state: string list, value: 'Duration) =
+            durationField "stable-after" value::state
+        /// Decision is taken by the strategy when there has been no membership or
+        /// reachability changes for this duration, i.e. the cluster state is stable.
+        member inline this.stable_after (value: 'Duration) =
+            this.StableAfter([], value)
+            |> this.Run
+
+    let split_brain_resolver =
+        { new SplitBrainResolverBuilder<Akka.Cluster.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "split-brain-resolver" 3 state
+                |> Akka.Cluster.Field }

--- a/src/Akkling.Hocon/Common.fs
+++ b/src/Akkling.Hocon/Common.fs
@@ -1,0 +1,195 @@
+﻿namespace Akkling.Hocon
+
+open System
+open System.ComponentModel
+
+[<EditorBrowsable(EditorBrowsableState.Never)>]
+module InternalHocon =
+    let inline notNegative name (x: 'T) =
+        if x < LanguagePrimitives.GenericZero<'T> then
+            failwithf "Cannot input negative value for field %s: %s" name (string x)
+
+    [<RequireQualifiedAccess>]
+    module private List =
+        let distinctSequential (xs: 'T list) =
+            []
+            |> List.foldBack (fun x xs ->
+                match xs with
+                | [] -> [x]
+                | [h] when h = x -> xs
+                | h::_ when h = x -> xs
+                | _ -> x::xs
+            ) xs
+        
+    type D1 = D1
+    type D2 = D2
+    type D3 = D3
+    type D4 = D4
+    type D5 = D5
+    type D6 = D6
+    type D7 = D7
+    type D8 = D8
+    type D9 = D9
+    type D10 = D10
+    type D11 = D11
+    type D12 = D12
+    type D13 = D13
+    type D14 = D14
+    type D15 = D15
+    type D16 = D16
+    type D17 = D17
+    type D18 = D18
+
+    type DurationToText = DurationToText with
+        static member (&.) (DurationToText, x: float<ns>) = fun D1 _ _ _ _ _ _ _ -> string x + " nanoseconds"
+        static member (&.) (DurationToText, x: int<ns>) = fun D1 _ _ _ _ _ _ _ -> string x + " nanoseconds"
+        
+        static member (&.) (DurationToText, x: float<us>) = fun D1 D2 _ _ _ _ _ _ -> string x + " microseconds"
+        static member (&.) (DurationToText, x: int<us>) = fun D1 D2 _ _ _ _ _ _ -> string x + " microseconds"
+        
+        static member (&.) (DurationToText, x: float<ms>) = fun D1 D2 D3 _ _ _ _ _ -> string x + " milliseconds"
+        static member (&.) (DurationToText, x: int<ms>) = fun D1 D2 D3 _ _ _ _ _ -> string x + " milliseconds"
+
+        static member (&.) (DurationToText, x: float<s>) = fun D1 D2 D3 D4 _ _ _ _ -> string x + " seconds"
+        static member (&.) (DurationToText, x: int<s>) = fun D1 D2 D3 D4 _ _ _ _ -> string x + " seconds"
+
+        static member (&.) (DurationToText, x: float<m>) = fun D1 D2 D3 D4 D5 _ _ _ -> string x + " minutes"
+        static member (&.) (DurationToText, x: int<m>) = fun D1 D2 D3 D4 D5 _ _ _ -> string x + " minutes"
+
+        static member (&.) (DurationToText, x: float<h>) = fun D1 D2 D3 D4 D5 D6 _ _ -> string x + " hours"
+        static member (&.) (DurationToText, x: int<h>) = fun D1 D2 D3 D4 D5 D6 _ _ -> string x + " hours"
+
+        static member (&.) (DurationToText, x: float<d>) = fun D1 D2 D3 D4 D5 D6 D7 _ -> string x + " days"
+        static member (&.) (DurationToText, x: int<d>) = fun D1 D2 D3 D4 D5 D6 D7 _ -> string x + " days"
+
+    let inline durationToText x : string = (Unchecked.defaultof<DurationToText> &. x) D1 D2 D3 D4 D5 D6 D7 D8
+
+    type BytesToText = BytesToText with
+        static member (&.) (BytesToText, x: int<B>) = fun D1 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ -> string x + " bytes"
+        static member (&.) (BytesToText, x: int<kB>) = fun D1 D2 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ -> string x + " kilobytes"
+        static member (&.) (BytesToText, x: int<KiB>) = fun D1 D2 D3 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ -> string x + " kibibytes"
+        static member (&.) (BytesToText, x: int<MB>) = fun D1 D2 D3 D4 _ _ _ _ _ _ _ _ _ _ _ _ _ _ -> string x + " megabytes"
+        static member (&.) (BytesToText, x: int<MiB>) = fun D1 D2 D3 D4 D5 _ _ _ _ _ _ _ _ _ _ _ _ _ -> string x + " mebibytes"
+        static member (&.) (BytesToText, x: int<GB>) = fun D1 D2 D3 D4 D5 D6 _ _ _ _ _ _ _ _ _ _ _ _ -> string x + " gigabytes"
+        static member (&.) (BytesToText, x: int<GiB>) = fun D1 D2 D3 D4 D5 D6 D7 _ _ _ _ _ _ _ _ _ _ _ -> string x + " gibibytes"
+        static member (&.) (BytesToText, x: int<TB>) = fun D1 D2 D3 D4 D5 D6 D7 D8 _ _ _ _ _ _ _ _ _ _ -> string x + " terabytes"
+        static member (&.) (BytesToText, x: int<TiB>) = fun D1 D2 D3 D4 D5 D6 D7 D8 D9 _ _ _ _ _ _ _ _ _ -> string x + " tebibytes"
+        static member (&.) (BytesToText, x: int<PB>) = fun D1 D2 D3 D4 D5 D6 D7 D8 D9 D10 _ _ _ _ _ _ _ _ -> string x + " petabytes"
+        static member (&.) (BytesToText, x: int<PiB>) = fun D1 D2 D3 D4 D5 D6 D7 D8 D9 D10 D11 _ _ _ _ _ _ _ -> string x + " pebibytes"
+        static member (&.) (BytesToText, x: int<EB>) = fun D1 D2 D3 D4 D5 D6 D7 D8 D9 D10 D11 D12 _ _ _ _ _ _ -> string x + " exabytes"
+        static member (&.) (BytesToText, x: int<EiB>) = fun D1 D2 D3 D4 D5 D6 D7 D8 D9 D10 D11 D12 D13 _ _ _ _ _ -> string x + " exbibytes"
+        static member (&.) (BytesToText, x: int<ZB>) = fun D1 D2 D3 D4 D5 D6 D7 D8 D9 D10 D11 D12 D13 D14 _ _ _ _ -> string x + " zettabytes"
+        static member (&.) (BytesToText, x: int<ZiB>) = fun D1 D2 D3 D4 D5 D6 D7 D8 D9 D10 D11 D12 D13 D14 D15 _ _ _ -> string x + " zebibytes"
+        static member (&.) (BytesToText, x: int<YB>) = fun D1 D2 D3 D4 D5 D6 D7 D8 D9 D10 D11 D12 D13 D14 D15 D16 _ _ -> string x + " yottabytes"
+        static member (&.) (BytesToText, x: int<YiB>) = fun D1 D2 D3 D4 D5 D6 D7 D8 D9 D10 D11 D12 D13 D14 D15 D16 D17 _ -> string x + " yobibytes"
+
+    let inline bytesToText x : string = (Unchecked.defaultof<BytesToText> &. x) D1 D2 D3 D4 D5 D6 D7 D8 D9 D10 D11 D12 D13 D14 D15 D16 D17 D18
+
+    let [<Literal>] Off = "off"
+    let [<Literal>] On = "on"
+
+    let nl = Environment.NewLine
+    let newLine x = x + nl
+    let wrapQuotes x = "\"" + x + "\""
+    let boolSwitch b = if b then On else Off
+
+    let indent i s = 
+        if s <> nl then
+            String.replicate i "    " + s
+        else s
+
+    let field name x = 
+        if String.IsNullOrEmpty x then 
+            sprintf "%s = \"\"" name
+        else sprintf "%s = %s" name x
+
+    let quotedField name x = wrapQuotes x |> field name
+    let quotedNameField name x = field (wrapQuotes name) x
+    let switchField name b = boolSwitch b |> field name
+    let boolField name b = sprintf "%s = %b" name b
+
+    let inline durationField name i = 
+        notNegative name i
+        field name (durationToText i)
+        
+    let inline byteField name i =
+        notNegative name i
+        field name (bytesToText i)
+
+    let inline numField name i =
+        sprintf "%s = %i" name i
+
+    let inline numFieldf name i =
+        sprintf "%s = %g" name i
+
+    let inline positiveField name i =
+        notNegative name i
+        numField name i
+        
+    let inline positiveFieldf name i =
+        notNegative name i
+        numFieldf name i
+
+    let inline portField name i =
+        if i > int UInt16.MaxValue then
+            failwithf "Port invalid: %i" i
+
+        positiveField name i
+
+    let listField name (x: string list) =
+        match x with
+        | []
+        | [""] -> sprintf "%s = []" name
+        | _ ->
+            String.concat "," x
+            |> sprintf "%s = [ %s ]" name
+
+    let quotedListField name (x: string list) =
+        List.map (wrapQuotes) x
+        |> listField name
+
+    let objExpr name indentLevel (body: string list) =
+        let body =
+            match body with
+            | [] -> body
+            | [h] when h.Trim() = nl -> []
+            | h::t when h.Trim() = nl ->
+                match List.rev t with
+                | [] -> t
+                | [h] when h.Trim() = nl -> []
+                | h::t when h.Trim() = nl -> t
+                | _ -> t
+            | _ -> body
+            |> List.distinctSequential 
+            |> List.map (indent indentLevel)
+            |> List.distinct
+            |> String.concat nl
+
+        sprintf "%s {%s%s%s%s}" name nl body nl (indent (indentLevel - 1) "")
+
+    let pathObjExpr (mkField: string -> 'Field) path indent name (body: string list) =
+        objExpr (sprintf "%s.%s" path name) indent body
+        |> mkField
+
+    let stringyObjExpr name indentLevel (body: (string * string) list) =
+        List.distinct body
+        |> List.map (fun (n,v) -> quotedNameField n v)
+        |> objExpr name indentLevel
+
+    [<AbstractClass;NoEquality;NoComparison>]
+    type BaseBuilder<'T when 'T :> MarkerClasses.IField> () =
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: string) = [x]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (a: unit) = []
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Combine (state: string list, x: string list) = x @ state
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Zero () = []
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Delay f = f()
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.For (xs: string list, f: unit -> string list) = f() @ xs
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        abstract Run : string list -> 'T

--- a/src/Akkling.Hocon/CoordinatedShutdown.fs
+++ b/src/Akkling.Hocon/CoordinatedShutdown.fs
@@ -1,0 +1,275 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module CoordinatedShutdown =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+    
+    [<AbstractClass>]
+    type PhaseBuilder<'T when 'T :> IField> (name: string) =
+        inherit BaseBuilder<'T>()
+
+        member internal _.Name = name
+
+        [<CustomOperation("depends_on");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.DependsOn (state: string list, values: string list) =
+            listField "depends-on" values::state
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.DependsOn (state: string list, values: PhaseBuilder<_> list) =
+            listField "depends-on" (values |> List.map (fun o -> o.Name))::state
+        member this.depends_on (value: string list) =
+            this.DependsOn([], value)
+            |> this.Run
+        member this.depends_on (value: PhaseBuilder<_> list) =
+            this.DependsOn([], value)
+            |> this.Run
+        
+        [<CustomOperation("timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.Timeout (state: string list, value: 'Duration) =
+            durationField "timeout" value::state
+        member inline this.timeout (value: 'Duration) =
+            this.Timeout([], value)
+            |> this.Run
+
+    let private createPhaseBuilder name =
+        { new PhaseBuilder<Akka.CoordinatedShutdown.Phases.Field>(name) with
+            member _.Run (state: string list) = 
+                objExpr name 4 state
+                |> Akka.CoordinatedShutdown.Phases.Field }
+
+    /// The first pre-defined phase that applications can add tasks to.
+    /// Note that more phases can be be added in the application's
+    /// configuration by overriding this phase with an additional 
+    /// depends-on.
+    let before_service_unbind = createPhaseBuilder "before-service-unbind"
+
+    /// Stop accepting new incoming requests in for example HTTP.
+    let service_unbind = createPhaseBuilder "service-unbind"
+
+    /// Wait for requests that are in progress to be completed.
+    let service_requests_done = createPhaseBuilder "service-requests-done"
+
+    /// Final shutdown of service endpoints.
+    let service_stop = createPhaseBuilder "service-stop"
+
+    /// Phase for custom application tasks that are to be run
+    /// after service shutdown and before cluster shutdown.
+    let before_cluster_shutdown = createPhaseBuilder "before-cluster-shutdown"
+
+    /// Graceful shutdown of the Cluster Sharding regions.
+    let cluster_sharding_shutdown_region = createPhaseBuilder "cluster-sharding-shutdown-region"
+
+    /// Emit the leave command for the node that is shutting down.
+    let cluster_leave = createPhaseBuilder "cluster-leave"
+
+    /// Shutdown cluster singletons
+    let cluster_exiting = createPhaseBuilder "cluster-exiting"
+
+    /// Wait until exiting has been completed
+    let cluster_exiting_done = createPhaseBuilder "cluster-exiting-done"
+
+    /// Shutdown the cluster extension
+    let cluster_shutdown = createPhaseBuilder "cluster-shutdown"
+
+    /// Phase for custom application tasks that are to be run
+    /// after cluster shutdown and before ActorSystem termination.
+    let before_actor_system_terminate = createPhaseBuilder "before-actor-system-terminate"
+
+    /// Last phase. See terminate-actor-system and exit-jvm above.
+    /// Don't add phases that depends on this phase because the 
+    /// dispatcher and scheduler of the ActorSystem have been shutdown. 
+    let actor_system_terminate = createPhaseBuilder "actor-system-terminate"
+    
+    [<AbstractClass>]
+    type PhasesBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string, indent: int) =
+        inherit BaseBuilder<'T>()
+        
+        let pathObjExpr = pathObjExpr mkField path indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.CoordinatedShutdown.Phases.Field) = [x.ToString()]
+
+        // Pathing
+
+        member private _.createPhaseBuilder name =
+            { new PhaseBuilder<'T>(name) with
+                member _.Run (state: string list) = pathObjExpr name state }
+
+        /// The first pre-defined phase that applications can add tasks to.
+        /// Note that more phases can be be added in the application's
+        /// configuration by overriding this phase with an additional 
+        /// depends-on.
+        member this.before_service_unbind = this.createPhaseBuilder "before-service-unbind"
+
+        /// Stop accepting new incoming requests in for example HTTP.
+        member this.service_unbind = this.createPhaseBuilder "service-unbind"
+
+        /// Wait for requests that are in progress to be completed.
+        member this.service_requests_done = this.createPhaseBuilder "service-requests-done"
+
+        /// Final shutdown of service endpoints.
+        member this.service_stop = this.createPhaseBuilder "service-stop"
+
+        /// Phase for custom application tasks that are to be run
+        /// after service shutdown and before cluster shutdown.
+        member this.before_cluster_shutdown = this.createPhaseBuilder "before-cluster-shutdown"
+
+        /// Graceful shutdown of the Cluster Sharding regions.
+        member this.cluster_sharding_shutdown_region = this.createPhaseBuilder "cluster-sharding-shutdown-region"
+
+        /// Emit the leave command for the node that is shutting down.
+        member this.cluster_leave = this.createPhaseBuilder "cluster-leave"
+
+        /// Shutdown cluster singletons
+        member this.cluster_exiting = this.createPhaseBuilder "cluster-exiting"
+
+        /// Wait until exiting has been completed
+        member this.cluster_exiting_done = this.createPhaseBuilder "cluster-exiting-done"
+
+        /// Shutdown the cluster extension
+        member this.cluster_shutdown = this.createPhaseBuilder "cluster-shutdown"
+
+        /// Phase for custom application tasks that are to be run
+        /// after cluster shutdown and before ActorSystem termination.
+        member this.before_actor_system_terminate = this.createPhaseBuilder "before-actor-system-terminate"
+
+        /// Last phase. See terminate-actor-system and exit-jvm above.
+        /// Don't add phases that depends on this phase because the 
+        /// dispatcher and scheduler of the ActorSystem have been shutdown. 
+        member this.actor_system_terminate = this.createPhaseBuilder "actor-system-terminate"
+
+    /// CoordinatedShutdown will run the tasks that are added to these
+    /// phases. 
+    ///
+    /// The phases can be ordered as a DAG by defining the 
+    /// dependencies between the phases.  
+    /// 
+    /// Each phase is defined as a named config section with the
+    /// following optional properties:
+    /// 
+    /// - timeout=15s: Override the default-phase-timeout for this phase.
+    /// 
+    /// - recover=off: If the phase fails the shutdown is aborted
+    ///                and depending phases will not be executed.
+    /// 
+    /// depends-on=[]: Run the phase after the given phases
+    let phases =
+        let path = "phases"
+        let indent = 3
+
+        { new PhasesBuilder<Akka.CoordinatedShutdown.Field>(Akka.CoordinatedShutdown.Field, path, indent) with
+            member _.Run (state: string list) = 
+                objExpr path indent state
+                |> Akka.CoordinatedShutdown.Field }
+
+    [<AbstractClass>]
+    type CoordinatedShutdownBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        let indent = 2
+        let pathObjExpr = pathObjExpr Akka.Field "coordinated-shutdown" indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.CoordinatedShutdown.Field) = [x.ToString()]
+        
+        /// The timeout that will be used for a phase if not specified with 
+        /// 'timeout' in the phase
+        [<CustomOperation("default_phase_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.DefaultPhaseTimeout (state: string list, value: 'Duration) =
+            durationField "default-phase-timeout" value::state
+        /// The timeout that will be used for a phase if not specified with 
+        /// 'timeout' in the phase
+        member inline this.default_phase_timeout (value: 'Duration) =
+            this.DefaultPhaseTimeout([], value)
+            |> this.Run
+            
+        /// Terminate the ActorSystem in the last phase actor-system-terminate.
+        [<CustomOperation("terminate_actor_system");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TerminateActorSystem (state: string list, value: bool) =
+            switchField "terminate-actor-system" value::state
+        member this.terminate_actor_system value =
+            this.TerminateActorSystem([], value)
+            |> this.Run
+    
+        /// Exit the CLR(Environment.Exit(0)) in the last phase actor-system-terminate
+        /// if this is set to 'on'. It is done after termination of the 
+        /// ActorSystem if terminate-actor-system=on, otherwise it is done 
+        /// immediately when the last phase is reached.  
+        [<CustomOperation("exit_clr");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ExitClr (state: string list, value: bool) =
+            switchField "exit-clr" value::state
+        /// Exit the CLR(Environment.Exit(0)) in the last phase actor-system-terminate
+        /// if this is set to 'on'. It is done after termination of the 
+        /// ActorSystem if terminate-actor-system=on, otherwise it is done 
+        /// immediately when the last phase is reached.  
+        member this.exit_clr value =
+            this.ExitClr([], value)
+            |> this.Run
+        
+        /// When shutting down the scheduler, there will typically be a thread which
+        /// needs to be stopped, and this timeout determines how long to wait for
+        /// that to happen. In case of timeout the shutdown of the actor system will
+        /// proceed without running possibly still enqueued tasks.
+        [<CustomOperation("run_by_clr_shutdown_hook");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.RunByClrShutdownHook (state: string list, value: bool) =
+            switchField "exit-clr" value::state
+        /// When shutting down the scheduler, there will typically be a thread which
+        /// needs to be stopped, and this timeout determines how long to wait for
+        /// that to happen. In case of timeout the shutdown of the actor system will
+        /// proceed without running possibly still enqueued tasks.
+        member this.run_by_clr_shutdown_hook value =
+            this.RunByClrShutdownHook([], value)
+            |> this.Run
+
+        /// Run the coordinated shutdown when ActorSystem.terminate is called.
+        /// Enabling this and disabling terminate-actor-system is not a supported
+        /// combination (will throw ConfigurationException at startup).
+        [<CustomOperation("run_by_actor_system_terminate");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.RunByActorSystemTerminate (state: string list, value: bool) =
+            switchField "run-by-actor-system-terminate" value::state
+        /// Run the coordinated shutdown when ActorSystem.terminate is called.
+        /// Enabling this and disabling terminate-actor-system is not a supported
+        /// combination (will throw ConfigurationException at startup).
+        member this.run_by_actor_system_terminate value =
+            this.RunByActorSystemTerminate([], value)
+            |> this.Run
+            
+        // Pathing
+
+        /// CoordinatedShutdown will run the tasks that are added to these
+        /// phases. 
+        ///
+        /// The phases can be ordered as a DAG by defining the 
+        /// dependencies between the phases.  
+        /// 
+        /// Each phase is defined as a named config section with the
+        /// following optional properties:
+        /// 
+        /// - timeout=15s: Override the default-phase-timeout for this phase.
+        /// 
+        /// - recover=off: If the phase fails the shutdown is aborted
+        ///                and depending phases will not be executed.
+        /// 
+        /// depends-on=[]: Run the phase after the given phases
+        member _.phases =
+            { new PhasesBuilder<Akka.Field>(Akka.Field, "coordinated-shutdown.phases", indent) with
+                member _.Run (state: string list) = pathObjExpr "phases" state }
+
+    /// CoordinatedShutdown is an extension that will perform registered
+    /// tasks in the order that is defined by the phases. It is started
+    /// by calling CoordinatedShutdown(system).run(). This can be triggered
+    /// by different things, for example:
+    ///
+    /// - JVM shutdown hook will by default run CoordinatedShutdown
+    ///
+    /// - Cluster node will automatically run CoordinatedShutdown when it
+    ///   sees itself as Exiting
+    ///
+    /// - A management console or other application specific command can 
+    ///   run CoordinatedShutdown
+    let coordinated_shutdown =
+        { new CoordinatedShutdownBuilder<Akka.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "coordinated-shutdown" 2 state
+                |> Akka.Field }

--- a/src/Akkling.Hocon/IO.Dns.fs
+++ b/src/Akkling.Hocon/IO.Dns.fs
@@ -1,0 +1,104 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Dns =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type INetAddressBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        /// Must implement akka.io.DnsProvider
+        [<CustomOperation("provider_object");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ProviderObject (state: string list, value: string) =
+            quotedField "provider-object" value::state
+        /// Must implement akka.io.DnsProvider
+        member this.provider_object value =
+            this.ProviderObject([], value)
+            |> this.Run
+        
+        [<CustomOperation("positive_ttl");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.PositiveTtl (state: string list, value: 'Duration) =
+            durationField "positive-ttl" value::state
+        member inline this.positive_ttl (value: 'Duration) =
+            this.PositiveTtl([], value)
+            |> this.Run
+        
+        [<CustomOperation("negative_ttl");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.NegativeTtl (state: string list, value: 'Duration) =
+            durationField "negative-ttl" value::state
+        member inline this.negative_ttl (value: 'Duration) =
+            this.NegativeTtl([], value)
+            |> this.Run
+        
+        /// How often to sweep out expired cache entries.
+        /// Note that this interval has nothing to do with TTLs
+        [<CustomOperation("cache_cleanup_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.CacheCleanupInterval (state: string list, value: 'Duration) =
+            durationField "cache-cleanup-interval" value::state
+        /// How often to sweep out expired cache entries.
+        /// Note that this interval has nothing to do with TTLs
+        member inline this.cache_cleanup_interval (value: 'Duration) =
+            this.CacheCleanupInterval([], value)
+            |> this.Run
+
+        [<CustomOperation("use_ipv6");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.UseIpv6 (state: string list, value: bool) =
+            boolField "use-ipv6" value::state
+        member this.use_ipv6 value =
+            this.UseIpv6([], value)
+            |> this.Run
+
+    let inet_address =
+        { new INetAddressBuilder<Akka.IO.INetAddress.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "inet-address" 4 state
+                |> Akka.IO.INetAddress.Field }
+
+    [<AbstractClass>]
+    type DnsBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string, indent: int) =
+        inherit BaseBuilder<'T>()
+
+        let pathObjExpr = pathObjExpr mkField path indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.IO.INetAddress.Field) = [x.ToString()]
+
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// for the manager and resolver router actors.
+        /// For actual router configuration see akka.actor.deployment./IO-DNS/*
+        [<CustomOperation("dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Dispatcher (state: string list, value: string) =
+            quotedField "dispatcher" value::state
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// for the manager and resolver router actors.
+        /// For actual router configuration see akka.actor.deployment./IO-DNS/*
+        member this.dispatcher value =
+            this.Dispatcher([], value)
+            |> this.Run
+            
+        /// Name of the subconfig at path akka.io.dns
+        [<CustomOperation("resolver");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Resolver (state: string list, value: string) =
+            quotedField "resolver" value::state
+        /// Name of the subconfig at path akka.io.dns
+        member this.resolver value =
+            this.Resolver([], value)
+            |> this.Run
+            
+        // Pathing
+
+        member _.inet_address =
+            { new INetAddressBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "inet-address" state }
+
+    let dns =
+        let path = "dns"
+        let indent = 3
+
+        { new DnsBuilder<Akka.IO.Field>(Akka.IO.Field, path, indent) with
+            member _.Run (state: string list) = 
+                objExpr path indent state
+                |> Akka.IO.Field }

--- a/src/Akkling.Hocon/IO.Pools.fs
+++ b/src/Akkling.Hocon/IO.Pools.fs
@@ -1,0 +1,106 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Pools =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type DirectBufferPoolBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        /// Class implementing `Akka.IO.Buffers.IBufferPool` interface, which
+        /// will be created with this configuration.
+        [<CustomOperation("class'");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Class (state: string list, value: string) =
+            quotedField "class" value::state
+        member this.class' value =
+            this.Class([], value)
+            |> this.Run
+            
+        /// Size of a single byte buffer in bytes.
+        [<CustomOperation("buffer_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.BufferSize (state: string list, value) =
+            positiveField "buffer-size" value::state
+        /// Size of a single byte buffer in bytes.
+        member inline this.buffer_size value =
+            this.BufferSize([], value)
+            |> this.Run
+            
+        /// Number of byte buffers per segment. Every segement is a single continuous
+        /// byte array in memory. Once buffer pool will run out of byte buffers to 
+        /// lend it will allocate a next segment of memory. 
+        /// Each segments size is equal to `buffer-size` * `buffers-per-segment`.
+        [<CustomOperation("buffers_per_segment");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.BuffersPerSegment (state: string list, value) =
+            positiveField "buffers-per-segment" value::state
+        member inline this.buffers_per_segment value =
+            this.BuffersPerSegment([], value)
+            |> this.Run
+    
+        /// Number of segments to be created at extension start.
+        [<CustomOperation("initial_segments");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.InitialSegments (state: string list, value) =
+            positiveField "initial-segments" value::state
+        /// Number of segments to be created at extension start.
+        member inline this.initial_segments value =
+            this.InitialSegments([], value)
+            |> this.Run
+            
+        /// Maximum number of segments that can be created by this byte buffer pool
+        /// instance. Once this limit will be reached, a next allocation attempt will
+        /// cause `BufferPoolAllocationException` to be thrown.
+        [<CustomOperation("buffer_pool_limit");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.BufferPoolLimit (state: string list, value) =
+            positiveField "buffer-pool-limit" value::state
+        /// Maximum number of segments that can be created by this byte buffer pool
+        /// instance. Once this limit will be reached, a next allocation attempt will
+        /// cause `BufferPoolAllocationException` to be thrown.
+        member inline this.buffer_pool_limit value =
+            this.BufferPoolLimit([], value)
+            |> this.Run
+
+    /// Implementation of `Akka.IO.Buffers.IBufferPool` interface. It
+    /// allocates memory is so called segments. Each segment is then cut into 
+    /// buffers of equal size (see: `buffers-per-segment`). Those buffers are 
+    /// then lend to the requestor. They have to be released later on.
+    let direct_buffer_pool =
+        { new DirectBufferPoolBuilder<Akka.IO.DirectBufferPool.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "direct-buffer-pool" 4 state
+                |> Akka.IO.DirectBufferPool.Field }
+
+    [<AbstractClass>]
+    type DisabledBufferPoolBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        /// Class implementing `Akka.IO.Buffers.IBufferPool` interface, which
+        /// will be created with this configuration.
+        [<CustomOperation("class'");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Class (state: string list, value: string) =
+            quotedField "class" value::state
+        /// Class implementing `Akka.IO.Buffers.IBufferPool` interface, which
+        /// will be created with this configuration.
+        member this.class' value =
+            this.Class([], value)
+            |> this.Run
+            
+        /// Size of a single byte buffer in bytes.
+        [<CustomOperation("buffer_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.BufferSize (state: string list, value) =
+            positiveField "buffer-size" value::state
+        /// Size of a single byte buffer in bytes.
+        member this.buffer_size value =
+            this.BufferSize([], value)
+            |> this.Run
+                
+    /// Default implementation of `Akka.IO.Buffers.IBufferPool` interface. 
+    /// Instead of maintaining allocated buffers and reusing them
+    /// between different SocketAsyncEventArgs instances, it allocates new 
+    /// buffer each time when new socket connection is established.
+    let disabled_buffer_pool =
+        { new DisabledBufferPoolBuilder<Akka.IO.DisabledBufferPool.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "disabled-buffer-pool" 4 state
+                |> Akka.IO.DisabledBufferPool.Field }

--- a/src/Akkling.Hocon/IO.fs
+++ b/src/Akkling.Hocon/IO.fs
@@ -1,0 +1,50 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module IO =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+    
+    [<AbstractClass>]
+    type IOBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        let indent = 2
+        let pathObjExpr = pathObjExpr Akka.Field "io" indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Actor.Dispatcher.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Shared.Field<Akka.Shared.Tcp.Field>) = [(x 3).ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Shared.Field<Akka.Shared.Udp.Field>) = [(x 3).ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.IO.Field) = [x.ToString()]
+        
+        // Pathing
+
+        member _.tcp =
+            { new TcpBuilder<Akka.Field>(Akka.Field, "io.tcp") with
+                member _.Run (state: SharedInternal.State<Tcp.Target>) = 
+                    fun _ -> pathObjExpr "tcp" state.Fields }
+
+        member _.udp = 
+            { new UdpBuilder<Akka.Field>(Akka.Field, "io.udp") with
+                member _.Run (state: SharedInternal.State<Udp.Target>) = 
+                    fun _ -> pathObjExpr "udp" state.Fields }
+
+        member _.udp_connected = 
+            { new UdpBuilder<Akka.Field>(Akka.Field, "io.udp-connected") with
+                member _.Run (state: SharedInternal.State<Udp.Target>) = 
+                    fun _ -> pathObjExpr "udp-connected" state.Fields }
+
+        member _.dns =
+            { new DnsBuilder<Akka.Field>(Akka.Field, "io.dns", indent) with
+                member _.Run (state: string list) = pathObjExpr "dns" state }
+
+    let io =
+        { new IOBuilder<Akka.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "io" 2 state
+                |> Akka.Field }

--- a/src/Akkling.Hocon/Persistence.AtLeastOnceDelivery.fs
+++ b/src/Akkling.Hocon/Persistence.AtLeastOnceDelivery.fs
@@ -1,0 +1,60 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module AtLeastOnceDelivery =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+    
+    [<AbstractClass>]
+    type AtLeastOnceDeliveryBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+            
+        /// Interval between re-delivery attempts.
+        [<CustomOperation("redeliver_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.RedeliverInterval (state: string list, value: 'Duration) =
+            durationField "redeliver-interval" value::state
+        /// Interval between re-delivery attempts.
+        member inline this.redeliver_interval (value: 'Duration) =
+            this.RedeliverInterval([], value)
+            |> this.Run
+        
+        /// Maximum number of unconfirmed messages that will be sent in one
+        /// re-delivery burst.
+        [<CustomOperation("redelivery_burst_limit");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.RedeliveryBurstLimit (state: string list, value: int) =
+            positiveField "redelivery-burst-limit" value::state
+        /// Maximum number of unconfirmed messages that will be sent in one
+        /// re-delivery burst.
+        member this.redelivery_burst_limit value =
+            this.RedeliveryBurstLimit([], value)
+            |> this.Run
+        
+        /// After this number of delivery attempts a
+        /// `ReliableRedelivery.UnconfirmedWarning`, message will be sent to the actor.
+        [<CustomOperation("warn_after_number_of_unconfirmed_attempts");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.WarnAfterNumberOfUnconfirmedAttempts (state: string list, value: int) =
+            positiveField "warn-after-number-of-unconfirmed-attempts" value::state
+        /// After this number of delivery attempts a
+        /// `ReliableRedelivery.UnconfirmedWarning`, message will be sent to the actor.
+        member this.warn_after_number_of_unconfirmed_attempts value =
+            this.WarnAfterNumberOfUnconfirmedAttempts([], value)
+            |> this.Run
+        
+        /// Maximum number of unconfirmed messages that an actor with
+        /// AtLeastOnceDelivery is allowed to hold in memory.
+        [<CustomOperation("max_unconfirmed_messages");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MaxUnconfirmedMessages (state: string list, value: int) =
+            positiveField "max-unconfirmed-messages" value::state
+        /// Maximum number of unconfirmed messages that an actor with
+        /// AtLeastOnceDelivery is allowed to hold in memory.
+        member this.max_unconfirmed_messages value =
+            this.MaxUnconfirmedMessages([], value)
+            |> this.Run
+    
+    /// Reliable delivery settings.
+    let at_least_once_delivery =
+        { new AtLeastOnceDeliveryBuilder<Akka.Persistence.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "at-least-once-delivery" 3 state
+                |> Akka.Persistence.Field }

--- a/src/Akkling.Hocon/Persistence.FSM.fs
+++ b/src/Akkling.Hocon/Persistence.FSM.fs
@@ -1,0 +1,53 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module FSM =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+    
+    [<AbstractClass>]
+    type FSMBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        /// PersistentFSM saves snapshots after this number of persistent
+        /// events. Snapshots are used to reduce recovery times.
+        ///
+        /// When you disable this feature, specify snapshot-after = off.
+        ///
+        /// To enable the feature, specify a number like snapshot-after = 1000
+        /// which means a snapshot is taken after persisting every 1000 events.
+        [<CustomOperation("snapshot_after");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SnapshotAfter (state: string list, value: int) =
+            positiveField "snapshot-after" value::state
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SnapshotAfter (state: string list, value: bool) =
+            if value then state
+            else switchField "snapshot-after" value::state
+        /// PersistentFSM saves snapshots after this number of persistent
+        /// events. Snapshots are used to reduce recovery times.
+        ///
+        /// When you disable this feature, specify snapshot-after = off.
+        ///
+        /// To enable the feature, specify a number like snapshot-after = 1000
+        /// which means a snapshot is taken after persisting every 1000 events.
+        member this.snapshot_after (value: int) =
+            this.SnapshotAfter([], value)
+            |> this.Run
+        /// PersistentFSM saves snapshots after this number of persistent
+        /// events. Snapshots are used to reduce recovery times.
+        ///
+        /// When you disable this feature, specify snapshot-after = off.
+        ///
+        /// To enable the feature, specify a number like snapshot-after = 1000
+        /// which means a snapshot is taken after persisting every 1000 events.
+        member this.snapshot_after (value: bool) =
+            this.SnapshotAfter([], value)
+            |> this.Run
+
+    /// Reliable delivery settings.
+    let fsm =
+        { new FSMBuilder<Akka.Persistence.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "fsm" 3 state
+                |> Akka.Persistence.Field}

--- a/src/Akkling.Hocon/Persistence.Journal.fs
+++ b/src/Akkling.Hocon/Persistence.Journal.fs
@@ -1,0 +1,72 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Journal =
+    open MarkerClasses
+    open InternalHocon
+    open SharedInternal
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type JournalBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string, indent: int) =
+        inherit BaseBuilder<'T>()
+        
+        let pathObjExpr = pathObjExpr mkField path indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Persistence.Plugin.Field) = [x.ToString()]
+            
+        /// Absolute path to the journal plugin configuration entry used by
+        /// persistent actor or view by default.
+        ///
+        /// Persistent actor or view can override `journalPluginId` method
+        /// in order to rely on a different journal plugin.
+        [<CustomOperation("plugin");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Plugin (state: string list, x: string) =
+            quotedField "plugin" x::state
+        /// Absolute path to the journal plugin configuration entry used by
+        /// persistent actor or view by default.
+        ///
+        /// Persistent actor or view can override `journalPluginId` method
+        /// in order to rely on a different journal plugin.
+        member this.plugin value =
+            this.Plugin([], value)
+            |> this.Run
+        
+        /// List of journal plugins to start automatically.
+        /// 
+        /// Use "" for the default journal plugin.
+        [<CustomOperation("auto_start_journals");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AutoStartJournals (state: string list, xs: string list) =
+            quotedListField "auto-start-journals" xs::state
+        /// List of journal plugins to start automatically.
+        /// 
+        /// Use "" for the default journal plugin.
+        member this.auto_start_journals value =
+            this.AutoStartJournals([], value)
+            |> this.Run
+        
+        // Pathing
+
+        member _.plugin_custom name =
+            let path = sprintf "%s.%s" path name
+
+            { new PluginBuilder<'T>(mkField, path, indent) with
+                member _.Run (state: State<Plugin.Target>) = pathObjExpr name state.Fields }
+
+        member _.inmem = plugin_custom "inmem"
+        
+        member _.proxy =
+            let path = sprintf "%s.proxy" path
+
+            { new ProxyBuilder<'T>(mkField, path, indent) with
+                member _.Run (state: State<Plugin.Target>) = pathObjExpr "proxy" state.Fields }
+
+    let journal =
+        let path = "journal"
+        let indent = 3
+
+        { new JournalBuilder<Akka.Persistence.Field>(Akka.Persistence.Field, path, indent) with
+            member _.Run (state: string list) = 
+                objExpr path indent state
+                |> Akka.Persistence.Field }

--- a/src/Akkling.Hocon/Persistence.Plugin.fs
+++ b/src/Akkling.Hocon/Persistence.Plugin.fs
@@ -1,0 +1,263 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Plugin =
+    open MarkerClasses
+    open InternalHocon
+    open SharedInternal
+    open System.ComponentModel
+    
+    [<AbstractClass>]
+    type CircuitBreakerBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        /// AtLeastOnceDelivery is allowed to hold in memory.
+        [<CustomOperation("max_failures");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MaxFailures (state: string list, value: int) =
+            positiveField "max-failures" value::state
+        /// AtLeastOnceDelivery is allowed to hold in memory.
+        member this.max_failures value =
+            this.MaxFailures([], value)
+            |> this.Run
+        
+        /// Interval between incremental updates.
+        [<CustomOperation("call_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.CallTimeout (state: string list, value: 'Duration) =
+            durationField "call-timeout" value::state
+        /// Interval between incremental updates.
+        member inline this.call_timeout (value: 'Duration) =
+            this.CallTimeout([], value)
+            |> this.Run
+        
+        /// Interval between incremental updates.
+        [<CustomOperation("reset_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ResetTimeout (state: string list, value: 'Duration) =
+            durationField "reset_timeout" value::state
+        /// Interval between incremental updates.
+        member inline this.reset_timeout (value: 'Duration) =
+            this.ResetTimeout([], value)
+            |> this.Run
+        
+    let circuit_breaker =
+        { new CircuitBreakerBuilder<Akka.Persistence.CircuitBreaker.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "jounal-plugin-fallback" 4 state
+                |> Akka.Persistence.CircuitBreaker.Field }
+
+    [<AbstractClass>]
+    type ReplayFilterBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        /// What the filter should do when detecting invalid events.
+        /// Supported values:
+        ///
+        /// `repair-by-discard-old` : discard events from old writers,
+        ///                           warning is logged
+        ///
+        /// `fail` : fail the replay, error is logged
+        ///
+        /// `warn` : log warning but emit events untouched
+        ///
+        /// `off` : disable this feature completely
+        [<CustomOperation("mode");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Mode (state: string list, value: Hocon.ReplayFilter.Mode) =
+            field "mode" value.Text::state
+        /// What the filter should do when detecting invalid events.
+        /// Supported values:
+        ///
+        /// `repair-by-discard-old` : discard events from old writers,
+        ///                           warning is logged
+        ///
+        /// `fail` : fail the replay, error is logged
+        ///
+        /// `warn` : log warning but emit events untouched
+        ///
+        /// `off` : disable this feature completely
+        member this.mode value =
+            this.Mode([], value)
+            |> this.Run
+        
+        /// It uses a look ahead buffer for analyzing the events.
+        ///
+        /// This defines the size (in number of events) of the buffer.
+        [<CustomOperation("window_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.WindowSize (state: string list, value: int) =
+            positiveField "window-size" value::state
+        /// It uses a look ahead buffer for analyzing the events.
+        ///
+        /// This defines the size (in number of events) of the buffer.
+        member this.window_size value =
+            this.WindowSize([], value)
+            |> this.Run
+        
+        /// How many old writerUuid to remember
+        [<CustomOperation("max_old_writers");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MaxOldWriters (state: string list, value: int) =
+            positiveField "max-old-writers" value::state
+        /// How many old writerUuid to remember
+        member this.max_old_writers value =
+            this.MaxOldWriters([], value)
+            |> this.Run
+        
+        /// Set this to `on` to enable detailed debug logging of each
+        /// replayed event.
+        [<CustomOperation("debug");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Debug (state: string list, value: bool) = 
+            switchField "debug" value::state
+        /// Set this to `on` to enable detailed debug logging of each
+        /// replayed event.
+        member this.debug value =
+            this.Debug([], value)
+            |> this.Run
+    
+    /// The replay filter can detect a corrupt event stream by inspecting
+    /// sequence numbers and writerUuid when replaying events.
+    let replay_filter =
+        { new ReplayFilterBuilder<Akka.Persistence.ReplayFilter.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "replay-filter" 4 state
+                |> Akka.Persistence.ReplayFilter.Field }
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    module Plugin =
+        [<RequireQualifiedAccess>]
+        type Target =
+            | Any
+            | Journal
+            | SnapshotStore
+        
+        [<RequireQualifiedAccess>]
+        module Target =
+            let merge (target1: Target) (target2: Target) =
+                match target1, target2 with
+                | Target.Any, _
+                | _, Target.Any
+                | _, _ when target1 = target2 -> Some target1
+                | _ -> None
+
+        [<RequireQualifiedAccess>]
+        module State =
+            let create = State.create Target.Any
+    
+    [<AbstractClass>]
+    type PluginBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string, indent: int) =    
+        let pathObjExpr = pathObjExpr mkField path indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        abstract Run : State<Plugin.Target> -> 'T
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: string) = Plugin.State.create [x]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Persistence.CircuitBreaker.Field) = Plugin.State.create [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Persistence.ReplayFilter.Field) = State.create Plugin.Target.SnapshotStore [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (a: unit) = Plugin.State.create []
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Combine (state1: State<Plugin.Target>, state2: State<Plugin.Target>) : State<Plugin.Target> = 
+            let fields = state1.Fields @ state2.Fields
+
+            match Plugin.Target.merge state1.Target state2.Target with
+            | Some target -> { Target = target; Fields = fields }
+            | None -> 
+                failwithf "Plugin only supports targeting a journal or snapshot, but was given fields for both.%s%A"
+                    System.Environment.NewLine fields
+
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Zero () = Plugin.State.create []
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Delay f = f()
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member this.For (state: State<Plugin.Target>, f: unit -> State<Plugin.Target>) = this.Combine(state, f())
+            
+        /// Fully qualified class name providing journal plugin api implementation.
+        /// It is mandatory to specify this property.
+        ///
+        /// The class must have a constructor without parameters or constructor with
+        /// one `Akka.Configuration.Config` parameter.
+        [<CustomOperation("class'");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Class (state: State<Plugin.Target>, x: string) =
+            quotedField "class" x
+            |> State.add state
+        /// Fully qualified class name providing journal plugin api implementation.
+        /// It is mandatory to specify this property.
+        ///
+        /// The class must have a constructor without parameters or constructor with
+        /// one `Akka.Configuration.Config` parameter.
+        member this.class' value =
+            this.Class(State.create Plugin.Target.Any [], value)
+            |> this.Run
+        
+        /// Dispatcher for the plugin actor.
+        [<CustomOperation("plugin_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.PluginDispatcher (state: State<Plugin.Target>, x: string) =
+            quotedField "plugin-dispatcher" x
+            |> State.add state
+        /// Dispatcher for the plugin actor.
+        member this.plugin_dispatcher value =
+            this.PluginDispatcher(State.create Plugin.Target.Any [], value)
+            |> this.Run
+        
+        /// Dispatcher for message replay.
+        [<CustomOperation("replay_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ReplayDispatcher (state: State<Plugin.Target>, x: string) =
+            quotedField "replay-dispatcher" x
+            |> State.addWith state Plugin.Target.Journal
+        /// Dispatcher for message replay.
+        member this.replay_dispatcher value =
+            this.ReplayDispatcher(State.create Plugin.Target.Journal [], value)
+            |> this.Run
+        
+        /// Default serializer used as manifest serializer when applicable and 
+        /// payload serializer when no specific binding overrides are specified
+        [<CustomOperation("serializer");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Serializer (state: State<Plugin.Target>, x: string) =
+            quotedField "serializer" x
+            |> State.add state
+        /// Default serializer used as manifest serializer when applicable and 
+        /// payload serializer when no specific binding overrides are specified
+        member this.serializer value =
+            this.Serializer(State.create Plugin.Target.Any [], value)
+            |> this.Run
+        
+        /// If there is more time in between individual events gotten from the Journal
+        /// recovery than this the recovery will fail.
+        ///
+        /// Note that it also affect reading the snapshot before replaying events on
+        /// top of it, even though iti is configured for the journal.
+        [<CustomOperation("recovery_event_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.RecoveryEventTimeout (state: State<Plugin.Target>, value: 'Duration) =
+            durationField "recovery-event-timeout" value
+            |> State.add state
+        /// If there is more time in between individual events gotten from the Journal
+        /// recovery than this the recovery will fail.
+        ///
+        /// Note that it also affect reading the snapshot before replaying events on
+        /// top of it, even though iti is configured for the journal.
+        member inline this.recovery_event_timeout (value: 'Duration) =
+            this.RecoveryEventTimeout(State.create Plugin.Target.Any [], value)
+            |> this.Run
+    
+        // Pathing
+        
+        member _.circuit_breaker =
+            { new CircuitBreakerBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "jounal-plugin-fallback" state }
+        
+        /// The replay filter can detect a corrupt event stream by inspecting
+        /// sequence numbers and writerUuid when replaying events.
+        member _.replay_filter =
+            { new ReplayFilterBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "replay-filter" state }
+
+    let plugin_custom name =
+        let indent = 4
+
+        { new PluginBuilder<Akka.Persistence.Plugin.Field>(Akka.Persistence.Plugin.Field, name, indent) with
+            member _.Run (state: State<Plugin.Target>) =
+                objExpr name 4 state.Fields
+                |> Akka.Persistence.Plugin.Field }
+
+    let inmem = plugin_custom "inmem"

--- a/src/Akkling.Hocon/Persistence.PluginFallback.fs
+++ b/src/Akkling.Hocon/Persistence.PluginFallback.fs
@@ -1,0 +1,133 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module PluginFallback =
+    open MarkerClasses
+    open InternalHocon
+    open SharedInternal
+    open System.ComponentModel
+    
+    [<AbstractClass>]
+    type PluginFallbackBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string, indent: int) =
+        inherit BaseBuilder<'T>()
+        
+        let pathObjExpr = pathObjExpr mkField path indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Persistence.CircuitBreaker.Field) = [x.ToString()]
+            
+        /// Fully qualified class name providing journal plugin api implementation.
+        /// It is mandatory to specify this property.
+        ///
+        /// The class must have a constructor without parameters or constructor with
+        /// one `Akka.Configuration.Config` parameter.
+        [<CustomOperation("class'");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Class (state: string list, x: string) =
+            quotedField "class" x::state
+        /// Fully qualified class name providing journal plugin api implementation.
+        /// It is mandatory to specify this property.
+        ///
+        /// The class must have a constructor without parameters or constructor with
+        /// one `Akka.Configuration.Config` parameter.
+        member this.class' value =
+            this.Class([], value)
+            |> this.Run
+        
+        /// Dispatcher for the plugin actor.
+        [<CustomOperation("plugin_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.PluginDispatcher (state: string list, x: string) =
+            quotedField "plugin-dispatcher" x::state
+        /// Dispatcher for the plugin actor.
+        member this.plugin_dispatcher value =
+            this.PluginDispatcher([], value)
+            |> this.Run
+
+        /// Default serializer used as manifest serializer when applicable and 
+        /// payload serializer when no specific binding overrides are specified
+        [<CustomOperation("serializer");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Serializer (state: string list, x: string) =
+            quotedField "serializer" x::state
+        /// Default serializer used as manifest serializer when applicable and 
+        /// payload serializer when no specific binding overrides are specified
+        member this.serializer value =
+            this.Serializer([], value)
+            |> this.Run
+    
+        // Pathing
+
+        member _.circuit_breaker =
+            { new CircuitBreakerBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "jounal-plugin-fallback" state }
+        
+        member _.proxy =
+            let path = sprintf "%s.proxy" path
+
+            { new ProxyBuilder<'T>(mkField, path, indent) with
+                member _.Run (state: State<Plugin.Target>) = pathObjExpr "proxy" state.Fields }
+
+    /// Fallback settings for snapshot store plugin configurations
+    ///
+    /// These settings are used if they are not defined in plugin config section.
+    let snapshot_store_plguin_fallback =
+        let path = "snapshot-store-plugin-fallback"
+        let indent = 3
+
+        { new PluginFallbackBuilder<Akka.Persistence.Field>(Akka.Persistence.Field, path, indent) with
+            member _.Run (state: string list) = 
+                objExpr path indent state
+                |> Akka.Persistence.Field }
+
+    [<AbstractClass>]
+    type JournalPluginFallbackBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string, indent: int) =
+        inherit PluginFallbackBuilder<'T>(mkField, path, indent)
+        
+        let pathObjExpr = pathObjExpr mkField path indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Persistence.ReplayFilter.Field) = [x.ToString()]
+            
+        /// Dispatcher for message replay.
+        [<CustomOperation("replay_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ReplayDispatcher (state: string list, x: string) =
+            quotedField "replay-dispatcher" x::state
+        /// Dispatcher for message replay.
+        member this.replay_dispatcher value =
+            this.ReplayDispatcher([], value)
+            |> this.Run
+        
+        /// If there is more time in between individual events gotten from the Journal
+        /// recovery than this the recovery will fail.
+        ///
+        /// Note that it also affect reading the snapshot before replaying events on
+        /// top of it, even though iti is configured for the journal.
+        [<CustomOperation("recovery_event_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.RecoveryEventTimeout (state: string list, value: 'Duration) =
+            durationField "recovery-event-timeout" value::state
+        /// If there is more time in between individual events gotten from the Journal
+        /// recovery than this the recovery will fail.
+        ///
+        /// Note that it also affect reading the snapshot before replaying events on
+        /// top of it, even though iti is configured for the journal.
+        member inline this.recovery_event_timeout (value: 'Duration) =
+            this.RecoveryEventTimeout([], value)
+            |> this.Run
+
+        // Pathing
+        
+        /// The replay filter can detect a corrupt event stream by inspecting
+        /// sequence numbers and writerUuid when replaying events.
+        member _.replay_filter =
+            { new ReplayFilterBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "replay-filter" state }
+
+    /// Fallback settings for journal plugin configurations.
+    ///
+    /// These settings are used if they are not defined in plugin config section.
+    let journal_plugin_fallback = 
+        let path = "jounal-plugin-fallback"
+        let indent = 3
+
+        { new JournalPluginFallbackBuilder<Akka.Persistence.Field>(Akka.Persistence.Field, path, indent) with
+            member _.Run (state: string list) = 
+                objExpr path indent state
+                |> Akka.Persistence.Field }

--- a/src/Akkling.Hocon/Persistence.Proxy.fs
+++ b/src/Akkling.Hocon/Persistence.Proxy.fs
@@ -1,0 +1,107 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Proxy =
+    open MarkerClasses
+    open InternalHocon
+    open SharedInternal
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type ProxyBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string, indent: int) =
+        inherit PluginBuilder<'T>(mkField, path, indent)
+
+        /// Set this to on in the configuration of the ActorSystem
+        /// that will host the target journal
+        [<CustomOperation("start_target_journal");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.StartTargetJournal (state: State<Plugin.Target>, value: bool) =
+            switchField "start-target-journal" value
+            |> State.addWith state Plugin.Target.Journal
+        /// Set this to on in the configuration of the ActorSystem
+        /// that will host the target journal
+        member this.start_target_journal value =
+            this.StartTargetJournal(State.create Plugin.Target.Journal [], value)
+            |> this.Run
+        
+        /// The journal plugin config path to use for the target journal
+        [<CustomOperation("target_journal_plugin");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TargetJournalPlugin (state: State<Plugin.Target>, x: string) =
+            quotedField "target-journal-plugin" x
+            |> State.addWith state Plugin.Target.Journal
+        /// The journal plugin config path to use for the target journal
+        member this.target_journal_plugin value =
+            this.TargetJournalPlugin(State.create Plugin.Target.Journal [], value)
+            |> this.Run
+        
+        /// The address of the proxy to connect to from other nodes. 
+        ///
+        /// Optional setting.
+        [<CustomOperation("target_journal_address");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TargetJournalAddress (state: State<Plugin.Target>, x: string) =
+            System.Uri(x) |> ignore
+
+            quotedField "target-journal-address" x
+            |> State.addWith state Plugin.Target.Journal
+        /// The address of the proxy to connect to from other nodes. 
+        ///
+        /// Optional setting.
+        member this.target_journal_address value =
+            this.TargetJournalAddress(State.create Plugin.Target.Journal [], value)
+            |> this.Run
+        
+        /// Set this to on in the configuration of the ActorSystem
+        /// that will host the target snapshot-store
+        [<CustomOperation("start_target_snapshot_store");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.StartTargetSnapshotStore (state: State<Plugin.Target>, value: bool) =
+            switchField "start-target-snapshot-store" value
+            |> State.addWith state Plugin.Target.SnapshotStore
+        /// Set this to on in the configuration of the ActorSystem
+        /// that will host the target snapshot-store
+        member this.start_target_snapshot_store value =
+            this.StartTargetSnapshotStore(State.create Plugin.Target.SnapshotStore [], value)
+            |> this.Run
+        
+        /// The journal plugin config path to use for the target snapshot-store
+        [<CustomOperation("target_snapshot_store_plugin");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TargetSnapshotStorePlugin (state: State<Plugin.Target>, x: string) =
+            quotedField "target-snapshot-store-plugin" x
+            |> State.addWith state Plugin.Target.SnapshotStore
+        /// The journal plugin config path to use for the target snapshot-store
+        member this.target_snapshot_store_plugin value =
+            this.TargetSnapshotStorePlugin(State.create Plugin.Target.SnapshotStore [], value)
+            |> this.Run
+        
+        /// The address of the proxy to connect to from other nodes. 
+        ///
+        /// Optional setting.
+        [<CustomOperation("target_snapshot_store_address");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TargetSnapshotStoreAddress (state: State<Plugin.Target>, x: string) =
+            System.Uri(x) |> ignore
+
+            quotedField "target-snapshot-store-address" x
+            |> State.addWith state Plugin.Target.SnapshotStore
+        /// The address of the proxy to connect to from other nodes. 
+        ///
+        /// Optional setting.
+        member this.target_snapshot_store_address value =
+            this.TargetSnapshotStoreAddress(State.create Plugin.Target.SnapshotStore [], value)
+            |> this.Run
+        
+        /// Initialization timeout of target lookup
+        [<CustomOperation("init_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.InitTimeout (state: State<Plugin.Target>, value: 'Duration) =
+            durationField "init-timeout" value
+            |> State.add state
+        /// Initialization timeout of target lookup
+        member inline this.init_timeout (value: 'Duration) =
+            this.InitTimeout(State.create Plugin.Target.Any [], value)
+            |> this.Run
+
+    let proxy =
+        let path = "proxy"
+        let indent = 4
+
+        { new ProxyBuilder<Akka.Persistence.Plugin.Field>(Akka.Persistence.Plugin.Field, path, indent) with
+            member _.Run (state: State<Plugin.Target>) =
+                objExpr path indent state.Fields
+                |> Akka.Persistence.Plugin.Field }

--- a/src/Akkling.Hocon/Persistence.SnapshotStore.fs
+++ b/src/Akkling.Hocon/Persistence.SnapshotStore.fs
@@ -1,0 +1,207 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module SnapshotStore =
+    open MarkerClasses
+    open InternalHocon
+    open SharedInternal
+    open System.ComponentModel
+    
+    [<AbstractClass>]
+    type LocalBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+            
+        /// Fully qualified class name providing journal plugin api implementation.
+        /// It is mandatory to specify this property.
+        ///
+        /// The class must have a constructor without parameters or constructor with
+        /// one `Akka.Configuration.Config` parameter.
+        [<CustomOperation("class'");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Class (state: string list, x: string) =
+            quotedField "class" x::state
+        /// Fully qualified class name providing journal plugin api implementation.
+        /// It is mandatory to specify this property.
+        ///
+        /// The class must have a constructor without parameters or constructor with
+        /// one `Akka.Configuration.Config` parameter.
+        member this.class' value =
+            this.Class([], value)
+            |> this.Run
+        
+        /// Dispatcher for the plugin actor.
+        [<CustomOperation("plugin_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.PluginDispatcher (state: string list, x: string) =
+            quotedField "plugin-dispatcher" x::state
+        /// Dispatcher for the plugin actor.
+        member this.plugin_dispatcher value =
+            this.PluginDispatcher([], value)
+            |> this.Run
+        
+        /// Default serializer used as manifest serializer when applicable and 
+        /// payload serializer when no specific binding overrides are specified
+        [<CustomOperation("serializer");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Serializer (state: string list, x: string) =
+            quotedField "serializer" x::state
+        /// Default serializer used as manifest serializer when applicable and 
+        /// payload serializer when no specific binding overrides are specified
+        member this.serializer value =
+            this.Serializer([], value)
+            |> this.Run
+        
+        /// If there is more time in between individual events gotten from the Journal
+        /// recovery than this the recovery will fail.
+        ///
+        /// Note that it also affect reading the snapshot before replaying events on
+        /// top of it, even though iti is configured for the journal.
+        [<CustomOperation("recovery_event_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.RecoveryEventTimeout (state: string list, value: 'Duration) =
+            durationField "recovery-event-timeout" value::state
+        /// If there is more time in between individual events gotten from the Journal
+        /// recovery than this the recovery will fail.
+        ///
+        /// Note that it also affect reading the snapshot before replaying events on
+        /// top of it, even though iti is configured for the journal.
+        member inline this.recovery_event_timeout (value: 'Duration) =
+            this.RecoveryEventTimeout([], value)
+            |> this.Run
+        
+        /// Dispatcher for streaming snapshot IO.
+        [<CustomOperation("stream_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.StreamDispatcher (state: string list, x: string) =
+            quotedField "stream-dispatcher" x::state
+        /// Dispatcher for streaming snapshot IO.
+        member this.stream_dispatcher value =
+            this.StreamDispatcher([], value)
+            |> this.Run
+        
+        /// Storage location of snapshot files.
+        [<CustomOperation("dir");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Dir (state: string list, x: string) =
+            quotedField "dir" x::state
+        /// Storage location of snapshot files.
+        member this.dir value =
+            this.Dir([], value)
+            |> this.Run
+        
+        /// Number load attempts when recovering from the latest snapshot fails
+        /// yet older snapshot files are available. Each recovery attempt will try
+        /// to recover using an older than previously failed-on snapshot file
+        /// (if any are present). If all attempts fail the recovery will fail and
+        /// the persistent actor will be stopped.
+        [<CustomOperation("max_load_attempts");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MaxLoadAttempts (state: string list, value: int) =
+            positiveField "max-load-attempts" value::state
+        /// Number load attempts when recovering from the latest snapshot fails
+        /// yet older snapshot files are available. Each recovery attempt will try
+        /// to recover using an older than previously failed-on snapshot file
+        /// (if any are present). If all attempts fail the recovery will fail and
+        /// the persistent actor will be stopped.
+        member this.max_load_attempts value =
+            this.MaxLoadAttempts([], value)
+            |> this.Run
+
+    let local =
+        { new LocalBuilder<Akka.Persistence.SnapshotStore.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "local" 4 state
+                |> Akka.Persistence.SnapshotStore.Field }
+
+    [<AbstractClass>]
+    type NoSnapshotStoreBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+            
+        [<CustomOperation("class'");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Class (state: string list, x: string) =
+            quotedField "class" x::state
+        member this.class' value =
+            this.Class([], value)
+            |> this.Run
+    
+    /// Used as default-snapshot store if no plugin configured
+    let no_snapshot_store =
+        { new NoSnapshotStoreBuilder<Akka.Persistence.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "no-snapshot-store" 3 state
+                |> Akka.Persistence.Field }
+    
+    [<AbstractClass>]
+    type SnapshotStoreBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string, indent: int) =
+        inherit BaseBuilder<'T>()
+        
+        let pathObjExpr = pathObjExpr mkField path indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Persistence.Plugin.Field) = [x.ToString()]
+            
+        /// Absolute path to the snapshot plugin configuration entry used by
+        /// persistent actor or view by default.
+        ///
+        /// Persistent actor or view can override `snapshotPluginId` method
+        /// in order to rely on a different snapshot plugin.
+        ///
+        /// It is not mandatory to specify a snapshot store plugin.
+        ///
+        /// If you don't use snapshots you don't have to configure it.
+        ///
+        /// Note that Cluster Sharding is using snapshots, so if you
+        /// use Cluster Sharding you need to define a snapshot store plugin.
+        [<CustomOperation("plugin");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Plugin (state: string list, x: string) =
+            quotedField "plugin" x::state
+        /// Absolute path to the snapshot plugin configuration entry used by
+        /// persistent actor or view by default.
+        ///
+        /// Persistent actor or view can override `snapshotPluginId` method
+        /// in order to rely on a different snapshot plugin.
+        ///
+        /// It is not mandatory to specify a snapshot store plugin.
+        ///
+        /// If you don't use snapshots you don't have to configure it.
+        ///
+        /// Note that Cluster Sharding is using snapshots, so if you
+        /// use Cluster Sharding you need to define a snapshot store plugin.
+        member this.plugin value =
+            this.Plugin([], value)
+            |> this.Run
+        
+        /// List of journal plugins to start automatically.
+        /// 
+        /// Use "" for the default snapshot store.
+        [<CustomOperation("auto_start_snapshot_stores");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AutoStartSnapshotStores (state: string list, xs: string list) =
+            quotedListField "auto-start-snapshot-stores" xs::state
+        /// List of journal plugins to start automatically.
+        /// 
+        /// Use "" for the default snapshot store.
+        member this.auto_start_snapshot_stores value =
+            this.AutoStartSnapshotStores([], value)
+            |> this.Run
+
+        // Pathing
+        
+        member _.local =
+            { new LocalBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "local" state }
+
+        member _.plugin_custom name =
+            let path = sprintf "%s.%s" path name
+
+            { new PluginBuilder<'T>(mkField, path, indent) with
+                member _.Run (state: State<Plugin.Target>) = pathObjExpr name state.Fields }
+
+        member _.inmem = plugin_custom "inmem"
+        
+        member _.proxy =
+            let path = sprintf "%s.proxy" path
+
+            { new ProxyBuilder<'T>(mkField, path, indent) with
+                member _.Run (state: State<Plugin.Target>) = pathObjExpr "proxy" state.Fields }
+
+    let snapshot_store =
+        let path = "snapshot-store"
+        let indent = 3
+
+        { new SnapshotStoreBuilder<Akka.Persistence.Field>(Akka.Persistence.Field, path, indent) with
+            member _.Run (state: string list) =
+                objExpr path indent state
+                |> Akka.Persistence.Field }

--- a/src/Akkling.Hocon/Persistence.View.fs
+++ b/src/Akkling.Hocon/Persistence.View.fs
@@ -1,0 +1,49 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module View =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+    
+    [<AbstractClass>]
+    type ViewBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+
+        /// Automated incremental view update.
+        [<CustomOperation("auto_update");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AutoUpdate (state: string list, value: bool) = 
+            switchField "auto-update" value::state
+        /// Automated incremental view update.
+        member this.auto_update value =
+            this.AutoUpdate([], value)
+            |> this.Run
+        
+        /// Interval between incremental updates.
+        [<CustomOperation("auto_update_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.AutoUpdateInterval (state: string list, value: 'Duration) =
+            durationField "auto-update-interval" value::state
+        /// Interval between incremental updates.
+        member inline this.auto_update_interval (value: 'Duration) =
+            this.AutoUpdateInterval([], value)
+            |> this.Run
+        
+        /// Maximum number of messages to replay per incremental view update.
+        ///
+        /// Set to -1 for no upper limit.
+        [<CustomOperation("auto_update_replay_max");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AutoUpdateReplayMax (state: string list, value: int) =
+            numField "auto-update-replay-max" value::state
+        /// Maximum number of messages to replay per incremental view update.
+        ///
+        /// Set to -1 for no upper limit.
+        member this.auto_update_replay_max value =
+            this.AutoUpdateReplayMax([], value)
+            |> this.Run
+    
+    /// Persistent view settings.
+    let view =
+        { new ViewBuilder<Akka.Persistence.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "view" 3 state
+                |> Akka.Persistence.Field }

--- a/src/Akkling.Hocon/Persistence.fs
+++ b/src/Akkling.Hocon/Persistence.fs
@@ -1,0 +1,99 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Persistence =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+    
+    [<AbstractClass>]
+    type PersistenceBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        let indent = 2
+        let pathObjExpr = pathObjExpr Akka.Field "actor" indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Actor.Dispatcher.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Persistence.Field) = [x.ToString()]
+        
+        /// When starting many persistent actors at the same time the journal
+        /// and its data store is protected from being overloaded by limiting number
+        /// of recoveries that can be in progress at the same time. When
+        /// exceeding the limit the actors will wait until other recoveries have
+        /// been completed.  
+        [<CustomOperation("max_concurrent_recoveries");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MaxConcurrentRecoveries (state: string list, value: int) =
+            positiveField "max-concurrent-recoveries" value::state
+        /// When starting many persistent actors at the same time the journal
+        /// and its data store is protected from being overloaded by limiting number
+        /// of recoveries that can be in progress at the same time. When
+        /// exceeding the limit the actors will wait until other recoveries have
+        /// been completed.  
+        member this.max_concurrent_recoveries value =
+            this.MaxConcurrentRecoveries([], value)
+            |> this.Run
+        
+        /// Fully qualified class name providing a default internal stash overflow strategy.
+        /// It needs to be a subclass of Akka.Persistence.StashOverflowStrategyConfigurator
+        /// The default strategy throws StashOverflowException
+        [<CustomOperation("internal_stash_overflow_strategy");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.InternalStashOverflowStrategy (state: string list, x: string) =
+            quotedField "internal-stash-overflow-strategy" x::state
+        /// Fully qualified class name providing a default internal stash overflow strategy.
+        /// It needs to be a subclass of Akka.Persistence.StashOverflowStrategyConfigurator
+        /// The default strategy throws StashOverflowException
+        member this.internal_stash_overflow_strategy value =
+            this.InternalStashOverflowStrategy([], value)
+            |> this.Run
+        
+        // Pathing
+        
+        /// Reliable delivery settings.
+        member _.fsm =
+            { new FSMBuilder<Akka.Field>() with
+                member _.Run (state: string list) = pathObjExpr "fsm" state }
+
+        /// Reliable delivery settings.
+        member _.at_least_once_delivery =
+            { new AtLeastOnceDeliveryBuilder<Akka.Field>() with
+                member _.Run (state: string list) = pathObjExpr "at-least-once-delivery" state }
+
+        /// Persistent view settings.
+        member _.view =
+            { new ViewBuilder<Akka.Field>() with
+                member _.Run (state: string list) = pathObjExpr "view" state }
+
+        /// Fallback settings for journal plugin configurations.
+        ///
+        /// These settings are used if they are not defined in plugin config section.
+        member _.journal_plugin_fallback = 
+            { new JournalPluginFallbackBuilder<Akka.Field>(Akka.Field, "persistence.jounal-plugin-fallback", indent) with
+                member _.Run (state: string list) = pathObjExpr "jounal-plugin-fallback" state }
+
+        /// Fallback settings for snapshot store plugin configurations
+        ///
+        /// These settings are used if they are not defined in plugin config section.
+        member _.snapshot_store_plguin_fallback = 
+            { new PluginFallbackBuilder<Akka.Field>(Akka.Field, "persistence.snapshot-store-plugin-fallback", indent) with
+                member _.Run (state: string list) = pathObjExpr "snapshot-store-plugin-fallback" state }
+
+        member _.journal =
+            { new JournalBuilder<Akka.Field>(Akka.Field, "persistence.journal", indent) with
+                member _.Run (state: string list) = pathObjExpr "journal" state }
+
+        /// Used as default-snapshot store if no plugin configured
+        member _.no_snapshot_store =
+            { new NoSnapshotStoreBuilder<Akka.Field>() with
+                member _.Run (state: string list) = pathObjExpr "no-snapshot-store" state }
+        
+        member _.snapshot_store =
+            { new SnapshotStoreBuilder<Akka.Field>(Akka.Field, "persistence.snapshot-store", indent) with
+                member _.Run (state: string list) = pathObjExpr "snapshot-store" state }
+
+    let persistence =
+        { new PersistenceBuilder<Akka.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "persistence" 2 state
+                |> Akka.Field }

--- a/src/Akkling.Hocon/Remote.DotNetty.fs
+++ b/src/Akkling.Hocon/Remote.DotNetty.fs
@@ -1,0 +1,457 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module DotNetty =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type CertificateBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+                
+        /// Valid certificate path required
+        [<CustomOperation("path");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Path (state: string list, x: string) = 
+            quotedField "path" x::state
+        /// Valid certificate path required
+        member this.path value =
+            this.Path([], value)
+            |> this.Run
+        
+        /// Valid certificate password required
+        [<CustomOperation("password");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Password (state: string list, x: string) = 
+            quotedField "password" x::state
+        /// Valid certificate password required
+        member this.password value =
+            this.Password([], value)
+            |> this.Run
+        
+        /// Default key storage flag is "default-key-set"
+        [<CustomOperation("flags");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Flags (state: string list, x: Hocon.Remoting.CertificateFlags list) = 
+            quotedListField "flags" (x |> List.map (fun x -> x.Text))::state
+        /// Default key storage flag is "default-key-set"
+        member this.flags value =
+            this.Flags([], value)
+            |> this.Run
+            
+        /// To use a Thumbprint instead of a file, set this to true
+        /// And specify a thumprint and it's storage location below
+        [<CustomOperation("use_thumprint_over_file");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.UseThumprintOverFile (state: string list, value: bool) = 
+            boolField "use-thumprint-over-file" value::state
+        /// To use a Thumbprint instead of a file, set this to true
+        /// And specify a thumprint and it's storage location below
+        member this.use_thumprint_over_file value =
+            this.UseThumprintOverFile([], value)
+            |> this.Run
+        
+        /// Valid Thumprint required (if use-thumbprint-over-file is true)
+        /// A typical thumbprint is a format similar to: "45df32e258c92a7abf6c112e54912ab15bbb9eb0"
+        /// On Windows machines, The thumprint for an installed certificate can be located
+        /// By using certlm.msc and opening the certificate under the 'Details' tab.
+        [<CustomOperation("thumpbrint");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Thumpbrint (state: string list, x: string) = 
+            quotedField "thumpbrint" x::state
+        /// Valid Thumprint required (if use-thumbprint-over-file is true)
+        /// A typical thumbprint is a format similar to: "45df32e258c92a7abf6c112e54912ab15bbb9eb0"
+        /// On Windows machines, The thumprint for an installed certificate can be located
+        /// By using certlm.msc and opening the certificate under the 'Details' tab.
+        member this.thumpbrint value =
+            this.Thumpbrint([], value)
+            |> this.Run
+        
+        /// The Store name. Under windows The most common option is "My", which indicates the personal store.
+        /// See System.Security.Cryptography.X509Certificates.StoreName for other common values.
+        [<CustomOperation("store_name");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.StoreName (state: string list, x: string) = 
+            quotedField "store-name" x::state
+        /// The Store name. Under windows The most common option is "My", which indicates the personal store.
+        /// See System.Security.Cryptography.X509Certificates.StoreName for other common values.
+        member this.store_name value =
+            this.StoreName([], value)
+            |> this.Run
+        
+        /// Valid options : local-machine or current-user
+        ///
+        /// current-user indicates a certificate stored under the user's account
+        ///
+        /// local-machine indicates a certificate stored at an operating system level (potentially shared by users)
+        [<CustomOperation("store_location");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.StoreLocation (state: string list, x: Hocon.Remoting.StoreLocation) = 
+            quotedField "store-location" (x.Text)::state
+        /// Valid options : local-machine or current-user
+        ///
+        /// current-user indicates a certificate stored under the user's account
+        ///
+        /// local-machine indicates a certificate stored at an operating system level (potentially shared by users)
+        member this.store_location value =
+            this.StoreLocation([], value)
+            |> this.Run
+        
+    let certificate = 
+        { new CertificateBuilder<Akka.Remote.Certificate.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "certificate" 4 state
+                |> Akka.Remote.Certificate.Field }
+    
+    [<AbstractClass>]
+    type SslProtocolBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string, indent: int) =
+        inherit BaseBuilder<'T>()
+        
+        let pathObjExpr = pathObjExpr mkField path indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Remote.Batching.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Remote.Certificate.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Remote.WorkerPool.Field) = [x.ToString()]
+        
+        /// The class given here must implement the akka.remote.transport.Transport
+        /// interface and offer a public constructor which takes two arguments:
+        ///
+        ///  1) akka.actor.ExtendedActorSystem
+        ///
+        ///  2) com.typesafe.config.Config
+        [<CustomOperation("transport_class");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TransportClass (state: string list, x: string) = 
+            quotedField "transport-class" x::state
+        /// The class given here must implement the akka.remote.transport.Transport
+        /// interface and offer a public constructor which takes two arguments:
+        ///
+        ///  1) akka.actor.ExtendedActorSystem
+        ///
+        ///  2) com.typesafe.config.Config
+        member this.transport_class value =
+            this.TransportClass([], value)
+            |> this.Run
+        
+        /// Transport drivers can be augmented with adapters by adding their
+        /// name to the applied-adapters list. The last adapter in the
+        /// list is the adapter immediately above the driver, while
+        /// the first one is the top of the stack below the standard
+        /// Akka protocol 
+        [<CustomOperation("applied_adapters");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AppliedAdapters (state: string list, x: string list) = 
+            quotedListField "applied-adapters" x::state
+        /// Transport drivers can be augmented with adapters by adding their
+        /// name to the applied-adapters list. The last adapter in the
+        /// list is the adapter immediately above the driver, while
+        /// the first one is the top of the stack below the standard
+        /// Akka protocol 
+        member this.applied_adapters value =
+            this.AppliedAdapters([], value)
+            |> this.Run
+            
+        /// Byte order used for network communication. Event thou DotNetty is big-endian
+        /// by default, we need to switch it back to little endian in order to support
+        /// backward compatibility with Helios.
+        [<CustomOperation("byte_order");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ByteOrder (state: string list, x: Hocon.ByteOrder) = 
+            quotedField "byte-order" (x.Text)::state
+        /// Byte order used for network communication. Event thou DotNetty is big-endian
+        /// by default, we need to switch it back to little endian in order to support
+        /// backward compatibility with Helios.
+        member this.byte_order value =
+            this.ByteOrder([], value)
+            |> this.Run
+        
+        /// The default remote server port clients should connect to.
+        /// Default is 2552 (AKKA), use 0 if you want a random available port
+        /// This port needs to be unique for each actor system on the same machine.
+        [<CustomOperation("port");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.Port (state: string list, x) =
+            positiveField "port" x::state
+        /// The default remote server port clients should connect to.
+        /// Default is 2552 (AKKA), use 0 if you want a random available port
+        /// This port needs to be unique for each actor system on the same machine.
+        member inline this.port value =
+            this.Port([], value)
+            |> this.Run
+            
+        /// Similar in spirit to "public-hostname" setting, this allows Akka.Remote users
+        /// to alias the port they're listening on. The socket will actually listen on the
+        /// "port" setting, but when connecting to other ActorSystems this node will advertise
+        /// itself as being connected to the "public-port". This is helpful when working with 
+        /// hosting environments that rely on address translation and port-forwarding, such as Docker.
+        ///
+        /// Leave this setting to "0" if you don't intend to use it.
+        [<CustomOperation("public_port");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.PublicPort (state: string list, x) =
+            positiveField "public-port" x::state
+        /// Similar in spirit to "public-hostname" setting, this allows Akka.Remote users
+        /// to alias the port they're listening on. The socket will actually listen on the
+        /// "port" setting, but when connecting to other ActorSystems this node will advertise
+        /// itself as being connected to the "public-port". This is helpful when working with 
+        /// hosting environments that rely on address translation and port-forwarding, such as Docker.
+        ///
+        /// Leave this setting to "0" if you don't intend to use it.
+        member inline this.public_port value =
+            this.PublicPort([], value)
+            |> this.Run
+            
+        /// The hostname or ip to bind the remoting to,
+        /// InetAddress.getLocalHost.getHostAddress is used if empty
+        [<CustomOperation("hostname");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Hostname (state: string list, x: string) = 
+            field "hostname" x::state
+        /// The hostname or ip to bind the remoting to,
+        /// InetAddress.getLocalHost.getHostAddress is used if empty
+        member this.hostname value =
+            this.Hostname([], value)
+            |> this.Run
+            
+        /// If this value is set, this becomes the public address for the actor system on this
+        /// transport, which might be different than the physical ip address (hostname)
+        /// this is designed to make it easy to support private / public addressing schemes
+        [<CustomOperation("public_hostname");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.PublicHostname (state: string list, x: string) = 
+            field "public-hostname" x::state
+        /// If this value is set, this becomes the public address for the actor system on this
+        /// transport, which might be different than the physical ip address (hostname)
+        /// this is designed to make it easy to support private / public addressing schemes
+        member this.public_hostname value =
+            this.PublicHostname([], value)
+            |> this.Run
+        
+        /// If set to true, we will use IPV6 addresses upon DNS resolution for host names.
+        /// Otherwise, we will use IPV4.
+        [<CustomOperation("dns_use_ipv6");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.DnsUseIpv6 (state: string list, value: bool) = 
+            boolField "dns-use-ipv6" value::state
+        /// If set to true, we will use IPV6 addresses upon DNS resolution for host names.
+        /// Otherwise, we will use IPV4.
+        member this.dns_use_ipv6 value =
+            this.DnsUseIpv6([], value)
+            |> this.Run
+        
+        /// If set to true, we will enforce usage of IPV4 or IPV6 addresses upon DNS resolution for host names.
+        /// If dns-use-ipv6 = true, we will use IPV6 enforcement
+        /// Otherwise, we will use IPV4.
+        /// Warning: when ip family is enforced, any connection between IPV4 and IPV6 is impossible
+        ///
+        /// enforce-ip-family setting is used only in some special cases, when default behaviour of 
+        /// underlying sockets leads to errors. Typically this occurs when an environment doesn't support
+        /// IPV6 or dual-mode sockets.
+        /// As of 09/21/2016 there are two known cases: running under Mono and in Azure WebApp  
+        /// for them we will need enforce-ip-family = true, and for Azure dns-use-ipv6 = false
+        /// This property is always set to true if Mono runtime is detected.
+        [<CustomOperation("enforce_ip_family");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.EnforceIpFamily (state: string list, value: bool) = 
+            boolField "enforce-ip-family" value::state
+        /// If set to true, we will enforce usage of IPV4 or IPV6 addresses upon DNS resolution for host names.
+        /// If dns-use-ipv6 = true, we will use IPV6 enforcement
+        /// Otherwise, we will use IPV4.
+        /// Warning: when ip family is enforced, any connection between IPV4 and IPV6 is impossible
+        ///
+        /// enforce-ip-family setting is used only in some special cases, when default behaviour of 
+        /// underlying sockets leads to errors. Typically this occurs when an environment doesn't support
+        /// IPV6 or dual-mode sockets.
+        /// As of 09/21/2016 there are two known cases: running under Mono and in Azure WebApp  
+        /// for them we will need enforce-ip-family = true, and for Azure dns-use-ipv6 = false
+        /// This property is always set to true if Mono runtime is detected.
+        member this.enforce_ip_family value =
+            this.EnforceIpFamily([], value)
+            |> this.Run
+            
+        /// Enables SSL support on this transport
+        [<CustomOperation("enable_ssl");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.EnableSsl (state: string list, value: bool) = 
+            boolField "enable-ssl" value::state
+        /// Enables SSL support on this transport
+        member this.enable_ssl value =
+            this.EnableSsl([], value)
+            |> this.Run
+            
+        /// Enables backwards compatibility with Akka.Remote clients running Helios 1.*
+        [<CustomOperation("enable_backwards_compatibility");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.EnableBackwardsCompatibility (state: string list, value: bool) = 
+            boolField "enable-backwards-compatibility" value::state
+        /// Enables backwards compatibility with Akka.Remote clients running Helios 1.*
+        member this.enable_backwards_compatibility value =
+            this.EnableBackwardsCompatibility([], value)
+            |> this.Run
+            
+        /// Sets the connectTimeoutMillis of all outbound connections,
+        /// i.e. how long a connect may take until it is timed out
+        [<CustomOperation("connection_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ConnectionTimeout (state: string list, value: 'Duration) =
+            durationField "connection-timeout" value::state
+        /// Sets the connectTimeoutMillis of all outbound connections,
+        /// i.e. how long a connect may take until it is timed out
+        member inline this.connection_timeout (value: 'Duration) =
+            this.ConnectionTimeout([], value)
+            |> this.Run
+            
+        /// If set to "<id.of.dispatcher>" then the specified dispatcher
+        /// will be used to accept inbound connections, and perform IO. If "" then
+        /// dedicated threads will be used.
+        ///
+        /// Please note that the Helios driver only uses this configuration and does
+        /// not read the "akka.remote.use-dispatcher" entry. Instead it has to be
+        /// configured manually to point to the same dispatcher if needed.
+        [<CustomOperation("use_dispatcher_for_io");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.UseDispatcherForIo (state: string list, x: string) = 
+            quotedField "use-dispatcher-for-io" x::state
+        /// If set to "<id.of.dispatcher>" then the specified dispatcher
+        /// will be used to accept inbound connections, and perform IO. If "" then
+        /// dedicated threads will be used.
+        ///
+        /// Please note that the Helios driver only uses this configuration and does
+        /// not read the "akka.remote.use-dispatcher" entry. Instead it has to be
+        /// configured manually to point to the same dispatcher if needed.
+        member this.use_dispatcher_for_io value =
+            this.UseDispatcherForIo([], value)
+            |> this.Run
+        
+        /// Sets the high water mark for the in and outbound sockets,
+        /// set to 0b for platform default
+        [<CustomOperation("write_buffer_high_water_mark");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.WriteBufferHighWaterMark (state: string list, value) =
+            byteField "write-buffer-high-water-mark" value::state
+        /// Sets the high water mark for the in and outbound sockets,
+        /// set to 0b for platform default
+        member inline this.write_buffer_high_water_mark value =
+            this.WriteBufferHighWaterMark([], value)
+            |> this.Run
+            
+        /// Sets the low water mark for the in and outbound sockets,
+        /// set to 0b for platform default
+        [<CustomOperation("write_buffer_low_water_mark");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.WriteBufferLowhWaterMark (state: string list, value) =
+            byteField "write-buffer-low-water-mark" value::state
+        /// Sets the low water mark for the in and outbound sockets,
+        /// set to 0b for platform default
+        member inline this.write_buffer_low_water_mark value =
+            this.WriteBufferLowhWaterMark([], value)
+            |> this.Run
+            
+        /// Sets the send buffer size of the Sockets,
+        /// set to 0b for platform default
+        [<CustomOperation("send_buffer_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.SendBufferSize (state: string list, value) =
+            byteField "send-buffer-size" value::state
+        /// Sets the send buffer size of the Sockets,
+        /// set to 0b for platform default
+        member inline this.send_buffer_size value =
+            this.SendBufferSize([], value)
+            |> this.Run
+            
+        /// Sets the receive buffer size of the Sockets,
+        /// set to 0b for platform default
+        [<CustomOperation("receive_buffer_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ReceiveBufferSize (state: string list, value) =
+            byteField "receive-buffer-size" value::state
+        /// Sets the receive buffer size of the Sockets,
+        /// set to 0b for platform default
+        member inline this.receive_buffer_size value =
+            this.ReceiveBufferSize([], value)
+            |> this.Run
+            
+        /// Maximum message size the transport will accept, but at least
+        /// 32000 bytes.
+        ///
+        /// Please note that UDP does not support arbitrary large datagrams,
+        /// so this setting has to be chosen carefully when using UDP.
+        /// Both send-buffer-size and receive-buffer-size settings has to
+        /// be adjusted to be able to buffer messages of maximum size.
+        [<CustomOperation("maximum_frame_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.MaximumFrameSize (state: string list, value) =
+            byteField "maximum-frame-size" value::state
+        /// Maximum message size the transport will accept, but at least
+        /// 32000 bytes.
+        ///
+        /// Please note that UDP does not support arbitrary large datagrams,
+        /// so this setting has to be chosen carefully when using UDP.
+        /// Both send-buffer-size and receive-buffer-size settings has to
+        /// be adjusted to be able to buffer messages of maximum size.
+        member inline this.maximum_frame_size value =
+            this.MaximumFrameSize([], value)
+            |> this.Run
+            
+        /// Sets the size of the connection backlog
+        [<CustomOperation("backlog");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.Backlog (state: string list, value) =
+            positiveField "backlog" value::state
+        /// Sets the size of the connection backlog
+        member inline this.backlog value =
+            this.Backlog([], value)
+            |> this.Run
+
+        [<CustomOperation("suppress_validation");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SuppressValidation (state: string list, value: bool) = 
+            boolField "suppress-validation" value::state
+        member this.suppress_validation value =
+            this.SuppressValidation([], value)
+            |> this.Run
+        
+        /// configured manually to point to the same dispatcher if needed.
+        [<CustomOperation("transport_protocol");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TransportProtocol (state: string list, x: string) = 
+            field "transport-protocol" x::state
+        /// configured manually to point to the same dispatcher if needed.
+        member this.transport_protocol value =
+            this.TransportProtocol([], value)
+            |> this.Run
+        
+        member _.client_socket_worker_pool = 
+            { new WorkerPoolBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "client-socket-worker-pool" state }
+
+        member _.server_socket_worker_pool = 
+            { new WorkerPoolBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "server-socket-worker-pool" state }
+        
+        member _.certificate = 
+            { new CertificateBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "certificate" state }
+        
+    let ssl = 
+        let path = "ssl"
+        let indent = 4
+
+        { new SslProtocolBuilder<Akka.Remote.DotNetty.Field>(Akka.Remote.DotNetty.Field, path, indent) with
+            member _.Run (state: string list) = 
+                objExpr path indent state
+                |> Akka.Remote.DotNetty.Field }
+    
+    [<AbstractClass>]
+    type DotNettyBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string, indent: int) =
+        inherit BaseBuilder<'T>()
+        
+        let pathObjExpr = pathObjExpr mkField path indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Remote.DotNetty.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Shared.Field<Akka.Shared.Tcp.Field>) = [(x 4).ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Shared.Field<Akka.Shared.Udp.Field>) = [(x 4).ToString()]
+
+        // Pathing
+
+        member _.tcp =
+            { new TcpBuilder<'T>(mkField, "dot-netty.tcp") with
+                member _.Run (state: SharedInternal.State<Tcp.Target>) = 
+                    fun _ -> pathObjExpr "tcp" state.Fields }
+
+        member _.udp = 
+            { new UdpBuilder<'T>(mkField, "dot-netty.udp") with
+                member _.Run (state: SharedInternal.State<Udp.Target>) = 
+                    fun _ -> pathObjExpr "udp" state.Fields }
+        
+        member _.ssl = 
+            { new SslProtocolBuilder<'T>(mkField, "dot-netty.ssl", indent) with
+                member _.Run (state: string list) = pathObjExpr "ssl" state }
+
+    let dot_netty = 
+        let path = "dot-netty"
+        let indent = 3
+
+        { new DotNettyBuilder<Akka.Remote.Field>(Akka.Remote.Field, path, indent) with
+            member _.Run (state: string list) = 
+                objExpr path indent state
+                |> Akka.Remote.Field }

--- a/src/Akkling.Hocon/Remote.Gremlin.fs
+++ b/src/Akkling.Hocon/Remote.Gremlin.fs
@@ -1,0 +1,26 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Gremlin =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type GremlinBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        /// Enable debug logging of the failure injector transport adapter
+        [<CustomOperation("debug");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Debug (state: string list, value: bool) = 
+            switchField "debug" value::state
+        /// Enable debug logging of the failure injector transport adapter
+        member this.debug value =
+            this.Debug([], value)
+            |> this.Run
+
+    let gremlin = 
+        { new GremlinBuilder<Akka.Remote.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "gremlin" 3 state
+                |> Akka.Remote.Field }

--- a/src/Akkling.Hocon/Remote.Protocols.fs
+++ b/src/Akkling.Hocon/Remote.Protocols.fs
@@ -1,0 +1,137 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Protocols =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    /// The batching feature of DotNetty is designed to help batch together logical writes into a smaller
+    /// number of physical writes across the socket. This helps significantly reduce the number of system calls
+    /// and can improve performance by as much as 150% on some systems when enabled.
+    [<AbstractClass>]
+    type BatchingBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+            
+        /// Enables the batching system. When disabled, every write will be flushed immediately.
+        /// Disable this setting if you're working with a VERY low-traffic system that requires
+        /// fast (< 40ms) acknowledgement for all periodic messages.
+        [<CustomOperation("enabled");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Enabled (state: string list, value: bool) = 
+            boolField "enabled" value::state
+        /// Enables the batching system. When disabled, every write will be flushed immediately.
+        /// Disable this setting if you're working with a VERY low-traffic system that requires
+        /// fast (< 40ms) acknowledgement for all periodic messages.
+        member this.enabled value =
+            this.Enabled([], value)
+            |> this.Run
+            
+        /// The max write threshold based on the number of logical messages regardless of their size. 
+        /// This is a safe default value - decrease it if you have a small number of remote actors
+        /// who engage in frequent request->response communication which requires low latency (< 40ms).
+        [<CustomOperation("max_pending_writes");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.MaxPendingWrites (state: string list, value) =
+            positiveField "max-pending-writes" value::state
+        /// The max write threshold based on the number of logical messages regardless of their size. 
+        /// This is a safe default value - decrease it if you have a small number of remote actors
+        /// who engage in frequent request->response communication which requires low latency (< 40ms).
+        member inline this.max_pending_writes value =
+            this.MaxPendingWrites([], value)
+            |> this.Run
+        
+        /// The max write threshold based on the byte size of all buffered messages. If there are 4 messages
+        /// waiting to be written (with batching.max-pending-writes = 30) but their total size is greater than
+        /// batching.max-pending-bytes, a flush will be triggered immediately.
+        ///
+        /// Increase this value is you have larger message sizes and watch to take advantage of batching, but
+        /// otherwise leave it as-is.
+        ///
+        /// NOTE: this value should always be smaller than dot-netty.tcp.maximum-frame-size.
+        [<CustomOperation("max_pending_bytes");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.MaxPendingBytes (state: string list, value) =
+            byteField "max-pending-bytes" value::state
+        /// The max write threshold based on the byte size of all buffered messages. If there are 4 messages
+        /// waiting to be written (with batching.max-pending-writes = 30) but their total size is greater than
+        /// batching.max-pending-bytes, a flush will be triggered immediately.
+        ///
+        /// Increase this value is you have larger message sizes and watch to take advantage of batching, but
+        /// otherwise leave it as-is.
+        ///
+        /// NOTE: this value should always be smaller than dot-netty.tcp.maximum-frame-size.
+        member inline this.max_pending_bytes value =
+            this.MaxPendingBytes([], value)
+            |> this.Run
+            
+        /// In the event that neither the batching.max-pending-writes or batching.max-pending-bytes
+        /// is hit we guarantee that all pending writes will be flushed within this interval.
+        ///
+        /// This setting, realistically, can't be enforced any lower than the OS' clock resolution (~20ms).
+        /// If you have a very low-traffic system, either disable pooling altogether or lower the batching.max-pending-writes
+        /// threshold to maximize throughput. Otherwise, leave this setting as-is.
+        [<CustomOperation("flush_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.FlushInterval (state: string list, value: 'Duration) =
+            durationField "flush-interval" value::state
+        /// In the event that neither the batching.max-pending-writes or batching.max-pending-bytes
+        /// is hit we guarantee that all pending writes will be flushed within this interval.
+        ///
+        /// This setting, realistically, can't be enforced any lower than the OS' clock resolution (~20ms).
+        /// If you have a very low-traffic system, either disable pooling altogether or lower the batching.max-pending-writes
+        /// threshold to maximize throughput. Otherwise, leave this setting as-is.
+        member inline this.flush_interval (value: 'Duration) =
+            this.FlushInterval([], value)
+            |> this.Run
+            
+    let batching =
+        { new BatchingBuilder<Akka.Remote.Batching.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "batching" 4 state
+                |> Akka.Remote.Batching.Field }
+
+    [<AbstractClass>]
+    type WorkerPoolBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+            
+        /// Min number of threads to cap factor-based number to
+        [<CustomOperation("pool_size_min");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.PoolSizeMin (state: string list, value) =
+            positiveField "pool-size-min" value::state
+        /// Min number of threads to cap factor-based number to
+        member inline this.pool_size_min value =
+            this.PoolSizeMin([], value)
+            |> this.Run
+        
+        /// The pool size factor is used to determine thread pool size
+        /// using the following formula: ceil(available processors * factor).
+        /// Resulting size is then bounded by the pool-size-min and
+        /// pool-size-max values.
+        [<CustomOperation("pool_size_factor");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.PoolSizeFactor (state: string list, value) =
+            positiveFieldf "pool-size-factor" value::state
+        /// The pool size factor is used to determine thread pool size
+        /// using the following formula: ceil(available processors * factor).
+        /// Resulting size is then bounded by the pool-size-min and
+        /// pool-size-max values.
+        member inline this.pool_size_factor value =
+            this.PoolSizeFactor([], value)
+            |> this.Run
+        
+        /// Max number of threads to cap factor-based number to
+        [<CustomOperation("pool_size_max");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.PoolSizeMax (state: string list, value) =
+            positiveField "pool-size-max" value::state
+        /// Max number of threads to cap factor-based number to
+        member inline this.pool_size_max value =
+            this.PoolSizeMax([], value)
+            |> this.Run
+        
+    let client_socket_worker_pool = 
+        { new WorkerPoolBuilder<Akka.Remote.WorkerPool.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "client-socket-worker-pool" 4 state
+                |> Akka.Remote.WorkerPool.Field }
+
+    let server_socket_worker_pool = 
+        { new WorkerPoolBuilder<Akka.Remote.WorkerPool.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "server-socket-worker-pool" 4 state
+                |> Akka.Remote.WorkerPool.Field }

--- a/src/Akkling.Hocon/Remote.TransportFailureDetector.fs
+++ b/src/Akkling.Hocon/Remote.TransportFailureDetector.fs
@@ -1,0 +1,63 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module TransportFailureDetector =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type TransportFailureDetectorBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        /// FQCN of the failure detector implementation.
+        /// It must implement akka.remote.FailureDetector and have
+        /// a public constructor with a com.typesafe.config.Config and
+        /// akka.actor.EventStream parameter.
+        [<CustomOperation("implementation_class");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ImplementationClass (state: string list, x: string) = 
+            quotedField "implementation-class" x::state
+        /// FQCN of the failure detector implementation.
+        /// It must implement akka.remote.FailureDetector and have
+        /// a public constructor with a com.typesafe.config.Config and
+        /// akka.actor.EventStream parameter.
+        member this.implementation_class value =
+            this.ImplementationClass([], value)
+            |> this.Run
+        
+        /// How often keep-alive heartbeat messages should be sent to each connection.
+        [<CustomOperation("heartbeat_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.HeartbeatInterval (state: string list, value: 'Duration) =
+            durationField "heartbeat-interval" value::state
+        /// How often keep-alive heartbeat messages should be sent to each connection.
+        member inline this.heartbeat_interval (value: 'Duration) =
+            this.HeartbeatInterval([], value)
+            |> this.Run
+        
+        /// Number of potentially lost/delayed heartbeats that will be
+        /// accepted before considering it to be an anomaly.
+        /// This margin is important to be able to survive sudden, occasional,
+        /// pauses in heartbeat arrivals, due to for example garbage collect or
+        /// network drop.
+        [<CustomOperation("acceptable_heartbeat_pause");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.AcceptableHeartbeatPause (state: string list, value: 'Duration) =
+            durationField "acceptable-heartbeat-pause" value::state
+        /// Number of potentially lost/delayed heartbeats that will be
+        /// accepted before considering it to be an anomaly.
+        /// This margin is important to be able to survive sudden, occasional,
+        /// pauses in heartbeat arrivals, due to for example garbage collect or
+        /// network drop.
+        member inline this.acceptable_heartbeat_pause (value: 'Duration) =
+            this.AcceptableHeartbeatPause([], value)
+            |> this.Run
+    
+    /// For TCP it is not important to have fast failure detection, since
+    /// most connection failures are captured by TCP itself.
+    /// The default DeadlineFailureDetector will trigger if there are no heartbeats within
+    /// the duration heartbeat-interval + acceptable-heartbeat-pause, i.e. 20 seconds
+    /// the duration heartbeat-interval + acceptable-heartbeat-pause, i.e. 124 seconds
+    let transport_failure_detector =
+        { new TransportFailureDetectorBuilder<Akka.Remote.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "transport-failure-detector" 3 state
+                |> Akka.Remote.Field }

--- a/src/Akkling.Hocon/Remote.WatchFailureDetector.fs
+++ b/src/Akkling.Hocon/Remote.WatchFailureDetector.fs
@@ -1,0 +1,127 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module WatchFailureDetector =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type WatchFailureDetectorBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        /// FQCN of the failure detector implementation.
+        /// It must implement akka.remote.FailureDetector and have
+        /// a public constructor with a com.typesafe.config.Config and
+        /// akka.actor.EventStream parameter.
+        [<CustomOperation("implementation_class");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ImplementationClass (state: string list, x: string) = 
+            quotedField "implementation-class" x::state
+        /// FQCN of the failure detector implementation.
+        /// It must implement akka.remote.FailureDetector and have
+        /// a public constructor with a com.typesafe.config.Config and
+        /// akka.actor.EventStream parameter.
+        member this.implementation_class value =
+            this.ImplementationClass([], value)
+            |> this.Run
+        
+        /// How often keep-alive heartbeat messages should be sent to each connection.
+        [<CustomOperation("heartbeat_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.HeartbeatInterval (state: string list, value: 'Duration) =
+            durationField "heartbeat-interval" value::state
+        /// How often keep-alive heartbeat messages should be sent to each connection.
+        member inline this.heartbeat_interval (value: 'Duration) =
+            this.HeartbeatInterval([], value)
+            |> this.Run
+        
+        /// Defines the failure detector threshold.
+        /// A low threshold is prone to generate many wrong suspicions but ensures
+        /// a quick detection in the event of a real crash. Conversely, a high
+        /// threshold generates fewer mistakes but needs more time to detect
+        /// actual crashes.
+        [<CustomOperation("threshold");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.Threshold (state: string list, x) = 
+            positiveFieldf "threshold" x::state
+        /// Defines the failure detector threshold.
+        /// A low threshold is prone to generate many wrong suspicions but ensures
+        /// a quick detection in the event of a real crash. Conversely, a high
+        /// threshold generates fewer mistakes but needs more time to detect
+        /// actual crashes.
+        member inline this.threshold value =
+            this.Threshold([], value)
+            |> this.Run
+            
+        /// Number of the samples of inter-heartbeat arrival times to adaptively
+        /// calculate the failure timeout for connections.
+        [<CustomOperation("max_sample_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.MaxSampleSize (state: string list, x) = 
+            positiveField "max-sample-size" x::state
+        /// Number of the samples of inter-heartbeat arrival times to adaptively
+        /// calculate the failure timeout for connections.
+        member inline this.max_sample_size value =
+            this.MaxSampleSize([], value)
+            |> this.Run
+            
+        /// Minimum standard deviation to use for the normal distribution in
+        /// AccrualFailureDetector. Too low standard deviation might result in
+        /// too much sensitivity for sudden, but normal, deviations in heartbeat
+        /// inter arrival times.
+        [<CustomOperation("min_std_deviation");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.MinStdDeviation (state: string list, value: 'Duration) =
+            durationField "min-std-deviation" value::state
+        /// Minimum standard deviation to use for the normal distribution in
+        /// AccrualFailureDetector. Too low standard deviation might result in
+        /// too much sensitivity for sudden, but normal, deviations in heartbeat
+        /// inter arrival times.
+        member inline this.min_std_deviation (value: 'Duration) =
+            this.MinStdDeviation([], value)
+            |> this.Run
+        
+        /// Number of potentially lost/delayed heartbeats that will be
+        /// accepted before considering it to be an anomaly.
+        /// This margin is important to be able to survive sudden, occasional,
+        /// pauses in heartbeat arrivals, due to for example garbage collect or
+        /// network drop.
+        [<CustomOperation("acceptable_heartbeat_pause");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.AcceptableHeartbeatPause (state: string list, value: 'Duration) =
+            durationField "acceptable-heartbeat-pause" value::state
+        /// Number of potentially lost/delayed heartbeats that will be
+        /// accepted before considering it to be an anomaly.
+        /// This margin is important to be able to survive sudden, occasional,
+        /// pauses in heartbeat arrivals, due to for example garbage collect or
+        /// network drop.
+        member inline this.acceptable_heartbeat_pause (value: 'Duration) =
+            this.AcceptableHeartbeatPause([], value)
+            |> this.Run
+        
+        /// How often to check for nodes marked as unreachable by the failure
+        /// detector
+        [<CustomOperation("unreachable_nodes_reaper_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.UnreachableNodesReaperInterval (state: string list, value: 'Duration) =
+            durationField "unreachable-nodes-reaper-interval" value::state
+        /// How often to check for nodes marked as unreachable by the failure
+        /// detector
+        member inline this.unreachable_nodes_reaper_interval (value: 'Duration) =
+            this.UnreachableNodesReaperInterval([], value)
+            |> this.Run
+        
+        /// After the heartbeat request has been sent the first failure detection
+        /// will start after this period, even though no heartbeat mesage has
+        /// been received.
+        [<CustomOperation("expected_response_after");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ExpectedResponseAfter (state: string list, value: 'Duration) =
+            durationField "expected-response-after" value::state
+        /// After the heartbeat request has been sent the first failure detection
+        /// will start after this period, even though no heartbeat mesage has
+        /// been received.
+        member inline this.expected_response_after (value: 'Duration) =
+            this.ExpectedResponseAfter([], value)
+            |> this.Run
+    
+    /// Settings for the Phi accrual failure detector (http://ddg.jaist.ac.jp/pub/HDY+04.pdf
+    /// [Hayashibara et al]) used for remote death watch.
+    let watch_failure_detector =
+        { new WatchFailureDetectorBuilder<Akka.Remote.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "watch-failure-detector" 3 state
+                |> Akka.Remote.Field }

--- a/src/Akkling.Hocon/Remote.fs
+++ b/src/Akkling.Hocon/Remote.fs
@@ -1,0 +1,526 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Remote =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+    
+    [<AbstractClass>]
+    type RemoteBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        let indent = 2
+        let pathObjExpr = pathObjExpr Akka.Field "remote" indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Remote.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Actor.Dispatcher.Field) = [x.ToString()]
+
+        /// Transport drivers can be augmented with adapters by adding their
+        /// name to the applied-adapters setting in the configuration of a
+        /// transport. The available adapters should be configured in this
+        /// section by providing a name, and the fully qualified name of
+        /// their corresponding implementation. The class given here
+        /// must implement Akka.Remote.Transport.TransportAdapterProvider
+        /// and have public constructor without parameters.
+        [<CustomOperation("adapters");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Adapters (state: string list, x: (string * string) list) = 
+            objExpr "adapters" 3 (x |> List.map (fun (n,v) -> quotedField n v))::state
+        /// Transport drivers can be augmented with adapters by adding their
+        /// name to the applied-adapters setting in the configuration of a
+        /// transport. The available adapters should be configured in this
+        /// section by providing a name, and the fully qualified name of
+        /// their corresponding implementation. The class given here
+        /// must implement Akka.Remote.Transport.TransportAdapterProvider
+        /// and have public constructor without parameters.
+        member this.adapters value =
+            this.Adapters([], value)
+            |> this.Run
+
+        /// Timeout after which the startup of the remoting subsystem is considered
+        /// to be failed. Increase this value if your transport drivers (see the
+        /// enabled-transports section) need longer time to be loaded.
+        [<CustomOperation("startup_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.StartupTimeout (state: string list, value: 'Duration) =
+            durationField "startup-timeout" value::state
+        /// Timeout after which the startup of the remoting subsystem is considered
+        /// to be failed. Increase this value if your transport drivers (see the
+        /// enabled-transports section) need longer time to be loaded.
+        member inline this.startup_timeout (value: 'Duration) =
+            this.StartupTimeout([], value)
+            |> this.Run
+            
+        /// Timout after which the graceful shutdown of the remoting subsystem is
+        /// considered to be failed. After the timeout the remoting system is
+        /// forcefully shut down. Increase this value if your transport drivers
+        /// (see the enabled-transports section) need longer time to stop properly.
+        [<CustomOperation("shutdown_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ShutdownTimeout (state: string list, value: 'Duration) =
+            durationField "shutdown-timeout" value::state
+        /// Timout after which the graceful shutdown of the remoting subsystem is
+        /// considered to be failed. After the timeout the remoting system is
+        /// forcefully shut down. Increase this value if your transport drivers
+        /// (see the enabled-transports section) need longer time to stop properly.
+        member inline this.shutdown_timeout (value: 'Duration) =
+            this.ShutdownTimeout([], value)
+            |> this.Run
+            
+        /// Before shutting down the drivers, the remoting subsystem attempts to flush
+        /// all pending writes. This setting controls the maximum time the remoting is
+        /// willing to wait before moving on to shut down the drivers.
+        [<CustomOperation("flust_wait_on_shutdown");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.FlushWaitOnShutdown (state: string list, value: 'Duration) =
+            durationField "flush-wait-on-shutdown" value::state
+        /// Before shutting down the drivers, the remoting subsystem attempts to flush
+        /// all pending writes. This setting controls the maximum time the remoting is
+        /// willing to wait before moving on to shut down the drivers.
+        member inline this.flust_wait_on_shutdown (value: 'Duration) =
+            this.FlushWaitOnShutdown([], value)
+            |> this.Run
+
+        /// Reuse inbound connections for outbound messages
+        [<CustomOperation("use_passive_connections");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.UsePassiveConnections (state: string list, value: bool) = 
+            switchField "use-passive-connections" value::state
+        /// Reuse inbound connections for outbound messages
+        member this.use_passive_connections value =
+            this.UsePassiveConnections([], value)
+            |> this.Run
+        
+        /// Controls the backoff interval after a refused write is reattempted.
+        /// (Transports may refuse writes if their internal buffer is full)
+        [<CustomOperation("backoff_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.BackoffInterval (state: string list, value: 'Duration) =
+            durationField "flush-wait-on-shutdown" value::state
+        /// Controls the backoff interval after a refused write is reattempted.
+        /// (Transports may refuse writes if their internal buffer is full)
+        member inline this.backoff_interval (value: 'Duration) =
+            this.BackoffInterval([], value)
+            |> this.Run
+        
+        /// Acknowledgment timeout of management commands sent to the transport stack.
+        [<CustomOperation("command_ack_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.CommandAckTimeout (state: string list, value: 'Duration) =
+            durationField "command-ack-timeout" value::state
+        /// Acknowledgment timeout of management commands sent to the transport stack.
+        member inline this.command_ack_timeout (value: 'Duration) =
+            this.CommandAckTimeout([], value)
+            |> this.Run
+        
+        /// The timeout for outbound associations to perform the handshake.
+        /// If the transport is akka.remote.dot-netty.tcp or akka.remote.dot-netty.ssl
+        /// the configured connection-timeout for the transport will be used instead.
+        [<CustomOperation("handshake_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.HandshakeTimeout (state: string list, value: 'Duration) =
+            durationField "handshake-timeout" value::state
+        /// The timeout for outbound associations to perform the handshake.
+        /// If the transport is akka.remote.dot-netty.tcp or akka.remote.dot-netty.ssl
+        /// the configured connection-timeout for the transport will be used instead.
+        member inline this.handshake_timeout (value: 'Duration) =
+            this.HandshakeTimeout([], value)
+            |> this.Run
+        
+        /// If set to a nonempty string remoting will use the given dispatcher for
+        /// its internal actors otherwise the default dispatcher is used. Please note
+        /// that since remoting can load arbitrary 3rd party drivers (see
+        /// "enabled-transport" and "adapters" entries) it is not guaranteed that
+        /// every module will respect this setting.
+        [<CustomOperation("use_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.UseDispatcher (state: string list, x: string) =
+            quotedField "use-dispatcher" x::state
+        /// If set to a nonempty string remoting will use the given dispatcher for
+        /// its internal actors otherwise the default dispatcher is used. Please note
+        /// that since remoting can load arbitrary 3rd party drivers (see
+        /// "enabled-transport" and "adapters" entries) it is not guaranteed that
+        /// every module will respect this setting.
+        member this.use_dispatcher value =
+            this.UseDispatcher([], value)
+            |> this.Run
+            
+        /// Enable untrusted mode for full security of server managed actors, prevents
+        /// system messages to be send by clients, e.g. messages like 'Create',
+        /// 'Suspend', 'Resume', 'Terminate', 'Supervise', 'Link' etc.
+        [<CustomOperation("untrusted_mode");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.UntrustedMode (state: string list, value: bool) = 
+            switchField "untrusted-mode" value::state
+        /// Enable untrusted mode for full security of server managed actors, prevents
+        /// system messages to be send by clients, e.g. messages like 'Create',
+        /// 'Suspend', 'Resume', 'Terminate', 'Supervise', 'Link' etc.
+        member this.untrusted_mode value =
+            this.UntrustedMode([], value)
+            |> this.Run
+        
+        /// When 'untrusted-mode=on' inbound actor selections are by default discarded.
+        /// Actors with paths defined in this white list are granted permission to receive actor
+        /// selections messages. 
+        ///
+        /// E.g. trusted-selection-paths = ["/user/receptionist", "/user/namingService"]   
+        [<CustomOperation("trusted_selection_paths");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TrustedSelectionPaths (state: string list, x: string list) = 
+            quotedListField "trusted-selection-paths" x::state
+        /// When 'untrusted-mode=on' inbound actor selections are by default discarded.
+        /// Actors with paths defined in this white list are granted permission to receive actor
+        /// selections messages. 
+        ///
+        /// E.g. trusted-selection-paths = ["/user/receptionist", "/user/namingService"]   
+        member this.trusted_selection_paths value =
+            this.TrustedSelectionPaths([], value)
+            |> this.Run
+            
+        /// Should the remote server require that its peers share the same
+        /// secure-cookie (defined in the 'remote' section)? Secure cookies are passed
+        /// between during the initial handshake. Connections are refused if the initial
+        /// message contains a mismatching cookie or the cookie is missing.
+        [<CustomOperation("require_cookie");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.RequireCookie (state: string list, value: bool) = 
+            switchField "require-cookie" value::state
+        /// Should the remote server require that its peers share the same
+        /// secure-cookie (defined in the 'remote' section)? Secure cookies are passed
+        /// between during the initial handshake. Connections are refused if the initial
+        /// message contains a mismatching cookie or the cookie is missing.
+        member this.require_cookie value =
+            this.RequireCookie([], value)
+            |> this.Run
+        
+        /// Generate your own with the script availbale in
+        /// '$AKKA_HOME/scripts/generate_config_with_secure_cookie.sh' or using
+        /// 'akka.util.Crypt.generateSecureCookie'
+        [<CustomOperation("secure_cookie");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SecureCookie (state: string list, x: string) =
+            quotedField "secure-cookie" x::state
+        /// Generate your own with the script availbale in
+        /// '$AKKA_HOME/scripts/generate_config_with_secure_cookie.sh' or using
+        /// 'akka.util.Crypt.generateSecureCookie'
+        member this.secure_cookie value =
+            this.SecureCookie([], value)
+            |> this.Run
+            
+        /// If this is "on", Akka will log all inbound messages at DEBUG level,
+        /// if off then they are not logged
+        [<CustomOperation("log_received_messages");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.LogReceivedMessages (state: string list, value: bool) = 
+            switchField "log-received-messages" value::state
+        /// If this is "on", Akka will log all inbound messages at DEBUG level,
+        /// if off then they are not logged
+        member this.log_received_messages value =
+            this.LogReceivedMessages([], value)
+            |> this.Run
+        
+        /// If this is "on", Akka will log all outbound messages at DEBUG level,
+        /// if off then they are not logged
+        [<CustomOperation("log_sent_messages");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.LogSentMessages (state: string list, value: bool) = 
+            switchField "log-sent-messages" value::state
+        /// If this is "on", Akka will log all outbound messages at DEBUG level,
+        /// if off then they are not logged
+        member this.log_sent_messages value =
+            this.LogSentMessages([], value)
+            |> this.Run
+        
+        /// Sets the log granularity level at which Akka logs remoting events. This setting
+        /// can take the values OFF, ERROR, WARNING, INFO, DEBUG, or ON. For compatibility
+        /// reasons the setting "on" will default to "debug" level. 
+        ///
+        /// Please note that the effective
+        /// logging level is still determined by the global logging level of the actor system:
+        /// for example debug level remoting events will be only logged if the system
+        /// is running with debug level logging.
+        ///
+        /// Failures to deserialize received messages also fall under this flag.
+        [<CustomOperation("log_remote_lifecycle_events");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.LogRemoteLifecycleEvents (state: string list, value: bool) = 
+            switchField "log-remote-lifecycle-events" value::state
+        /// Sets the log granularity level at which Akka logs remoting events. This setting
+        /// can take the values OFF, ERROR, WARNING, INFO, DEBUG, or ON. For compatibility
+        /// reasons the setting "on" will default to "debug" level. 
+        ///
+        /// Please note that the effective
+        /// logging level is still determined by the global logging level of the actor system:
+        /// for example debug level remoting events will be only logged if the system
+        /// is running with debug level logging.
+        ///
+        /// Failures to deserialize received messages also fall under this flag.
+        member this.log_remote_lifecycle_events value =
+            this.LogRemoteLifecycleEvents([], value)
+            |> this.Run
+        
+        /// Logging of message types with payload size in bytes larger than
+        /// this value. Maximum detected size per message type is logged once,
+        /// with an increase threshold of 10%.
+        ///
+        /// By default this feature is turned off. Activate it by setting the property to
+        /// a value in bytes, such as 1000b. Note that for all messages larger than this
+        /// limit there will be extra performance and scalability cost.
+        [<CustomOperation("log_frame_size_exceeding");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.LogFrameEizeExceeding (state: string list, value) =
+            byteField "log-frame-size-exceeding" value::state
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.LogFrameEizeExceeding (state: string list, value: bool) = 
+            if value then
+                field "log-frame-size-exceeding" "off"::state
+            else state
+        /// Logging of message types with payload size in bytes larger than
+        /// this value. Maximum detected size per message type is logged once,
+        /// with an increase threshold of 10%.
+        ///
+        /// By default this feature is turned off. Activate it by setting the property to
+        /// a value in bytes, such as 1000b. Note that for all messages larger than this
+        /// limit there will be extra performance and scalability cost.
+        member inline this.log_frame_size_exceeding value =
+            byteField "log-frame-size-exceeding" value::[]
+            |> this.Run
+        /// Logging of message types with payload size in bytes larger than
+        /// this value. Maximum detected size per message type is logged once,
+        /// with an increase threshold of 10%.
+        ///
+        /// By default this feature is turned off. Activate it by setting the property to
+        /// a value in bytes, such as 1000b. Note that for all messages larger than this
+        /// limit there will be extra performance and scalability cost.
+        member this.log_frame_size_exceeding (value: bool) =
+            this.LogFrameEizeExceeding([], value)
+            |> this.Run
+
+        /// Log warning if the number of messages in the backoff buffer in the endpoint
+        /// writer exceeds this limit. It can be disabled by setting the value to off.
+        [<CustomOperation("log_buffer_size_exceeding");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.LogBufferSizeExceeding (state: string list, value) = 
+            positiveField "log-buffer-size-exceeding" value::state
+        /// Log warning if the number of messages in the backoff buffer in the endpoint
+        /// writer exceeds this limit. It can be disabled by setting the value to off.
+        member this.log_buffer_size_exceeding value =
+            this.LogBufferSizeExceeding([], value)
+            |> this.Run
+        
+        /// After failed to establish an outbound connection, the remoting will mark the
+        /// address as failed. This configuration option controls how much time should
+        /// be elapsed before reattempting a new connection. While the address is
+        /// gated, all messages sent to the address are delivered to dead-letters.
+        /// Since this setting limits the rate of reconnects setting it to a
+        /// very short interval (i.e. less than a second) may result in a storm of
+        /// reconnect attempts.
+        [<CustomOperation("retry_gate_closed_for");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.RetryGateClosedFor (state: string list, value: 'Duration) =
+            durationField "retry-gate-closed-for" value::state
+        /// After failed to establish an outbound connection, the remoting will mark the
+        /// address as failed. This configuration option controls how much time should
+        /// be elapsed before reattempting a new connection. While the address is
+        /// gated, all messages sent to the address are delivered to dead-letters.
+        /// Since this setting limits the rate of reconnects setting it to a
+        /// very short interval (i.e. less than a second) may result in a storm of
+        /// reconnect attempts.
+        member inline this.retry_gate_closed_for (value: 'Duration) =
+            this.RetryGateClosedFor([], value)
+            |> this.Run
+        
+        /// After catastrophic communication failures that result in the loss of system
+        /// messages or after the remote DeathWatch triggers the remote system gets
+        /// quarantined to prevent inconsistent behavior.
+        /// This setting controls how long the Quarantine marker will be kept around
+        /// before being removed to avoid long-term memory leaks.
+        ///
+        /// WARNING: DO NOT change this to a small value to re-enable communication with
+        /// quarantined nodes. Such feature is not supported and any behavior between
+        /// the affected systems after lifting the quarantine is undefined.
+        [<CustomOperation("prune_quarantine_marker_after");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.PruneQuarantineMarkerAfter (state: string list, value: 'Duration) =
+            durationField "prune-quarantine-marker-after" value::state
+        /// After catastrophic communication failures that result in the loss of system
+        /// messages or after the remote DeathWatch triggers the remote system gets
+        /// quarantined to prevent inconsistent behavior.
+        /// This setting controls how long the Quarantine marker will be kept around
+        /// before being removed to avoid long-term memory leaks.
+        ///
+        /// WARNING: DO NOT change this to a small value to re-enable communication with
+        /// quarantined nodes. Such feature is not supported and any behavior between
+        /// the affected systems after lifting the quarantine is undefined.
+        member inline this.prune_quarantine_marker_after (value: 'Duration) =
+            this.PruneQuarantineMarkerAfter([], value)
+            |> this.Run
+        
+        /// If system messages have been exchanged between two systems (i.e. remote death
+        /// watch or remote deployment has been used) a remote system will be marked as
+        /// quarantined after the two system has no active association, and no
+        /// communication happens during the time configured here.
+        ///
+        /// The only purpose of this setting is to avoid storing system message redelivery
+        /// data (sequence number state, etc.) for an undefined amount of time leading to long
+        /// term memory leak. Instead, if a system has been gone for this period,
+        /// or more exactly
+        ///
+        /// - there is no association between the two systems (TCP connection, if TCP transport is used)
+        ///
+        /// - neither side has been attempting to communicate with the other
+        ///
+        /// - there are no pending system messages to deliver
+        ///
+        /// for the amount of time configured here, the remote system will be quarantined and all state
+        /// associated with it will be dropped.
+        [<CustomOperation("quarantine_after_silence");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.QuarantineAfterSilence (state: string list, value: 'Duration) =
+            durationField "quarantine-after-silence" value::state
+        /// If system messages have been exchanged between two systems (i.e. remote death
+        /// watch or remote deployment has been used) a remote system will be marked as
+        /// quarantined after the two system has no active association, and no
+        /// communication happens during the time configured here.
+        ///
+        /// The only purpose of this setting is to avoid storing system message redelivery
+        /// data (sequence number state, etc.) for an undefined amount of time leading to long
+        /// term memory leak. Instead, if a system has been gone for this period,
+        /// or more exactly
+        ///
+        /// - there is no association between the two systems (TCP connection, if TCP transport is used)
+        ///
+        /// - neither side has been attempting to communicate with the other
+        ///
+        /// - there are no pending system messages to deliver
+        ///
+        /// for the amount of time configured here, the remote system will be quarantined and all state
+        /// associated with it will be dropped.
+        member inline this.quarantine_after_silence (value: 'Duration) =
+            this.QuarantineAfterSilence([], value)
+            |> this.Run
+        
+        /// This setting defines the maximum number of unacknowledged system messages
+        /// allowed for a remote system. If this limit is reached the remote system is
+        /// declared to be dead and its UID marked as tainted.
+        [<CustomOperation("system_message_buffer_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.SystemMessageBufferSize (state: string list, value) =
+            positiveField "system-message-buffer-size" value::state
+        /// This setting defines the maximum number of unacknowledged system messages
+        /// allowed for a remote system. If this limit is reached the remote system is
+        /// declared to be dead and its UID marked as tainted.
+        member inline this.system_message_buffer_size value =
+            this.SystemMessageBufferSize([], value)
+            |> this.Run
+        
+        /// This setting defines the maximum idle time after an individual
+        /// acknowledgement for system messages is sent. System message delivery
+        /// is guaranteed by explicit acknowledgement messages. These acks are
+        /// piggybacked on ordinary traffic messages. If no traffic is detected
+        /// during the time period configured here, the remoting will send out
+        /// an individual ack.
+        [<CustomOperation("system_message_ack_piggyback_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.SystemMessageAckPiggybackTimeout (state: string list, value: 'Duration) =
+            durationField "system-message-ack-piggyback-timeout" value::state
+        /// This setting defines the maximum idle time after an individual
+        /// acknowledgement for system messages is sent. System message delivery
+        /// is guaranteed by explicit acknowledgement messages. These acks are
+        /// piggybacked on ordinary traffic messages. If no traffic is detected
+        /// during the time period configured here, the remoting will send out
+        /// an individual ack.
+        member inline this.system_message_ack_piggyback_timeout (value: 'Duration) =
+            this.SystemMessageAckPiggybackTimeout([], value)
+            |> this.Run
+        
+        /// This setting defines the time after internal management signals
+        /// between actors (used for DeathWatch and supervision) that have not been
+        /// explicitly acknowledged or negatively acknowledged are resent.
+        /// Messages that were negatively acknowledged are always immediately
+        /// resent.
+        [<CustomOperation("resend_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ResendInterval (state: string list, value: 'Duration) =
+            durationField "resend-interval" value::state
+        /// This setting defines the time after internal management signals
+        /// between actors (used for DeathWatch and supervision) that have not been
+        /// explicitly acknowledged or negatively acknowledged are resent.
+        /// Messages that were negatively acknowledged are always immediately
+        /// resent.
+        member inline this.resend_interval (value: 'Duration) =
+            this.ResendInterval([], value)
+            |> this.Run
+        
+        /// Maximum number of unacknowledged system messages that will be resent
+        /// each 'resend-interval'. If you watch many (> 1000) remote actors you can
+        /// increase this value to for example 600, but a too large limit (e.g. 10000)
+        /// may flood the connection and might cause false failure detection to trigger.
+        /// Test such a configuration by watching all actors at the same time and stop
+        /// all watched actors at the same time.
+        [<CustomOperation("resend_limit");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ResendLimit (state: string list, value) =
+            positiveField "resend-limit" value::state
+        /// Maximum number of unacknowledged system messages that will be resent
+        /// each 'resend-interval'. If you watch many (> 1000) remote actors you can
+        /// increase this value to for example 600, but a too large limit (e.g. 10000)
+        /// may flood the connection and might cause false failure detection to trigger.
+        /// Test such a configuration by watching all actors at the same time and stop
+        /// all watched actors at the same time.
+        member inline this.resend_limit value =
+            this.ResendLimit([], value)
+            |> this.Run
+        
+        /// WARNING: this setting should not be not changed unless all of its consequences
+        /// are properly understood which assumes experience with remoting internals
+        /// or expert advice.
+        ///
+        /// This setting defines the time after redelivery attempts of internal management
+        /// signals are stopped to a remote system that has been not confirmed to be alive by
+        /// this system before.
+        [<CustomOperation("initial_system_message_delivery_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.InitialSystemMessageDeliveryTimeout (state: string list, value: 'Duration) =
+            durationField "initial-system-message-delivery-timeout" value::state
+        /// WARNING: this setting should not be not changed unless all of its consequences
+        /// are properly understood which assumes experience with remoting internals
+        /// or expert advice.
+        ///
+        /// This setting defines the time after redelivery attempts of internal management
+        /// signals are stopped to a remote system that has been not confirmed to be alive by
+        /// this system before.
+        member inline this.initial_system_message_delivery_timeout (value: 'Duration) =
+            this.InitialSystemMessageDeliveryTimeout([], value)
+            |> this.Run
+        
+        /// List of the transport drivers that will be loaded by the remoting.
+        ///
+        /// A list of fully qualified config paths must be provided where
+        /// the given configuration path contains a transport-class key
+        /// pointing to an implementation class of the Transport interface.
+        ///
+        /// If multiple transports are provided, the address of the first
+        /// one will be used as a default address.
+        [<CustomOperation("enabled_transports");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.EnabledTransports (state: string list, x: string list) = 
+            quotedListField "enabled-transports" x::state
+        /// List of the transport drivers that will be loaded by the remoting.
+        ///
+        /// A list of fully qualified config paths must be provided where
+        /// the given configuration path contains a transport-class key
+        /// pointing to an implementation class of the Transport interface.
+        ///
+        /// If multiple transports are provided, the address of the first
+        /// one will be used as a default address.
+        member this.enabled_transports value =
+            this.EnabledTransports([], value)
+            |> this.Run
+            
+        // Pathing
+        
+        /// For TCP it is not important to have fast failure detection, since
+        /// most connection failures are captured by TCP itself.
+        /// The default DeadlineFailureDetector will trigger if there are no heartbeats within
+        /// the duration heartbeat-interval + acceptable-heartbeat-pause, i.e. 20 seconds
+        /// the duration heartbeat-interval + acceptable-heartbeat-pause, i.e. 124 seconds
+        member _.transport_failure_detector =
+            { new TransportFailureDetectorBuilder<Akka.Field>() with
+                member _.Run (state: string list) = pathObjExpr "transport-failure-detector" state }
+                
+        /// Settings for the Phi accrual failure detector (http://ddg.jaist.ac.jp/pub/HDY+04.pdf
+        /// [Hayashibara et al]) used for remote death watch.
+        member _.watch_failure_detector =
+            { new WatchFailureDetectorBuilder<Akka.Field>() with
+                member _.Run (state: string list) = pathObjExpr "watch-failure-detector" state }
+                
+        member _.gremlin = 
+            { new GremlinBuilder<Akka.Field>() with
+                member _.Run (state: string list) = pathObjExpr "gremlin" state }
+        
+        member _.dot_netty = 
+            { new DotNettyBuilder<Akka.Field>(Akka.Field, "remote.dot-netty", indent) with
+                member _.Run (state: string list) = pathObjExpr "dot-netty" state }
+
+    let remote =
+        { new RemoteBuilder<Akka.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "remote" 2 state
+                |> Akka.Field }

--- a/src/Akkling.Hocon/Scheduler.fs
+++ b/src/Akkling.Hocon/Scheduler.fs
@@ -1,0 +1,115 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Scheduler =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    [<AbstractClass>]
+    type SchedulerBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        /// The LightArrayRevolverScheduler is used as the default scheduler in the
+        /// system. It does not execute the scheduled tasks on exact time, but on every
+        /// tick, it will run everything that is (over)due. You can increase or decrease
+        /// the accuracy of the execution timing by specifying smaller or larger tick
+        /// duration. If you are scheduling a lot of tasks you should consider increasing
+        /// the ticks per wheel.
+        ///
+        /// Note that it might take up to 1 tick to stop the Timer, so setting the
+        /// tick-duration to a high value will make shutting down the actor system
+        /// take longer.
+        [<CustomOperation("tick_duration");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.TickDuration (state: string list, value: 'Duration) =
+            durationField "tick-duration" value::state
+        /// The LightArrayRevolverScheduler is used as the default scheduler in the
+        /// system. It does not execute the scheduled tasks on exact time, but on every
+        /// tick, it will run everything that is (over)due. You can increase or decrease
+        /// the accuracy of the execution timing by specifying smaller or larger tick
+        /// duration. If you are scheduling a lot of tasks you should consider increasing
+        /// the ticks per wheel.
+        ///
+        /// Note that it might take up to 1 tick to stop the Timer, so setting the
+        /// tick-duration to a high value will make shutting down the actor system
+        /// take longer.
+        member inline this.tick_duration (value: 'Duration) =
+            this.TickDuration([], value)
+            |> this.Run
+            
+        /// The timer uses a circular wheel of buckets to store the timer tasks.
+        ///
+        /// This should be set such that the majority of scheduled timeouts (for high
+        /// scheduling frequency) will be shorter than one rotation of the wheel
+        /// (ticks-per-wheel * ticks-duration)
+        ///
+        /// THIS MUST BE A POWER OF TWO!
+        [<CustomOperation("ticks_per_wheel");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.TicksPerWheel (state: string list, value: int) =
+            if (value &&& (value - 1)) = 0 then
+                numField "ticks-per-wheel" value::state
+            else failwithf "ticks-per-wheel must be a power of 2, was given: %i" value
+        /// The timer uses a circular wheel of buckets to store the timer tasks.
+        ///
+        /// This should be set such that the majority of scheduled timeouts (for high
+        /// scheduling frequency) will be shorter than one rotation of the wheel
+        /// (ticks-per-wheel * ticks-duration)
+        ///
+        /// THIS MUST BE A POWER OF TWO!
+        member inline this.ticks_per_wheel (value: int) =
+            this.TicksPerWheel([], value)
+            |> this.Run
+            
+        /// This setting selects the timer implementation which shall be loaded at
+        /// system start-up.
+        /// The class given here must implement the akka.actor.Scheduler interface
+        /// and offer a public constructor which takes three arguments:
+        ///
+        ///  1) com.typesafe.config.Config
+        ///
+        ///  2) akka.event.LoggingAdapter
+        ///
+        ///  3) java.util.concurrent.ThreadFactory
+        [<CustomOperation("implementation");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Implementation (state: string list, value: string) =
+            quotedField "implementation" value::state
+        /// This setting selects the timer implementation which shall be loaded at
+        /// system start-up.
+        /// The class given here must implement the akka.actor.Scheduler interface
+        /// and offer a public constructor which takes three arguments:
+        ///
+        ///  1) com.typesafe.config.Config
+        ///
+        ///  2) akka.event.LoggingAdapter
+        ///
+        ///  3) java.util.concurrent.ThreadFactory
+        member this.implementation value =
+            this.Implementation([], value)
+            |> this.Run
+    
+        /// When shutting down the scheduler, there will typically be a thread which
+        /// needs to be stopped, and this timeout determines how long to wait for
+        /// that to happen. In case of timeout the shutdown of the actor system will
+        /// proceed without running possibly still enqueued tasks.
+        [<CustomOperation("shutdown_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ShutdownTimeout (state: string list, value: 'Duration) =
+            durationField "shutdown-timeout" value::state
+        /// When shutting down the scheduler, there will typically be a thread which
+        /// needs to be stopped, and this timeout determines how long to wait for
+        /// that to happen. In case of timeout the shutdown of the actor system will
+        /// proceed without running possibly still enqueued tasks.
+        member inline this.shutdown_timeout (value: 'Duration) =
+            this.ShutdownTimeout([], value)
+            |> this.Run
+
+    /// Used to set the behavior of the scheduler.
+    ///
+    /// Changing the default values may change the system behavior drastically so make
+    /// sure you know what you're doing! 
+    ///
+    /// See the Scheduler section of the Akka documentation for more details.
+    let scheduler = 
+        { new SchedulerBuilder<Akka.Scheduler.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "scheduler" 2 state
+                |> Akka.Scheduler.Field }

--- a/src/Akkling.Hocon/Shared.Cluster.fs
+++ b/src/Akkling.Hocon/Shared.Cluster.fs
@@ -1,0 +1,777 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Cluster =
+    open MarkerClasses
+    open InternalHocon
+    open SharedInternal
+    open System.ComponentModel
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    module Cluster =
+        [<RequireQualifiedAccess>]
+        type Target =
+            | Any
+            | Cluster
+            | DeploymentDefault
+        
+        [<RequireQualifiedAccess>]
+        module Target =
+            let merge (target1: Target) (target2: Target) =
+                match target1, target2 with
+                | Target.Any, _
+                | _, Target.Any -> Some target1
+                | _, _ when target1 = target2 -> Some target1
+                | _ -> None
+
+        [<RequireQualifiedAccess>]
+        module State =
+            let create = State.create Target.Any
+            
+    [<AbstractClass>]
+    type ClusterBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string) =
+        let pathObjExpr = pathObjExpr mkField path
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        abstract Run : State<Cluster.Target> -> Akka.Shared.Field<'T>
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: string) = Cluster.State.create [x]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Cluster.Field) = State.create Cluster.Target.Cluster [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Scheduler.Field) = State.create Cluster.Target.Cluster [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Shared.Field<Akka.Shared.Debug.Field>) = State.create Cluster.Target.Cluster [(x 3).ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (a: unit) = Cluster.State.create []
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Combine (state1: State<Cluster.Target>, state2: State<Cluster.Target>) : State<Cluster.Target> =
+            let fields = state1.Fields @ state2.Fields
+
+            match Cluster.Target.merge state1.Target state2.Target with
+            | Some target -> { Target = target; Fields = fields }
+            | None -> 
+                failwithf "Cluster fields mismatch found was given:%s%A"
+                    System.Environment.NewLine fields
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Zero () = Cluster.State.create []
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Delay f = f()
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member this.For (state: State<Cluster.Target>, f: unit -> State<Cluster.Target>) = this.Combine(state, f())
+        
+        // Akka.Cluster
+
+        /// Initial contact points of the cluster.
+        /// The nodes to join automatically at startup.
+        ///
+        /// Comma separated full URIs defined by a string on the form of
+        /// "akka.tcp://system@hostname:port"
+        ///
+        /// Leave as empty if the node is supposed to be joined manually.
+        [<CustomOperation("seed_nodes");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SeedNodes (state: State<Cluster.Target>, xs: string list) =
+            xs |> List.iter (System.Uri >> ignore)
+            quotedListField "seed-nodes" xs
+            |> State.addWith state Cluster.Target.Cluster
+        /// Initial contact points of the cluster.
+        /// The nodes to join automatically at startup.
+        ///
+        /// Comma separated full URIs defined by a string on the form of
+        /// "akka.tcp://system@hostname:port"
+        ///
+        /// Leave as empty if the node is supposed to be joined manually.
+        member this.seed_nodes value =
+            this.SeedNodes(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+        
+        /// How long to wait for one of the seed nodes to reply to initial join request.
+        ///
+        /// When this is the first seed node and there is no positive reply from the other
+        /// seed nodes within this timeout it will join itself to bootstrap the cluster.
+        ///
+        /// When this is not the first seed node the join attempts will be performed with
+        /// this interval.
+        [<CustomOperation("seed_node_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.SeedNodeTimeout (state: State<Cluster.Target>, value: 'Duration) =
+            durationField "seed-node-timeout" value
+            |> State.addWith state Cluster.Target.Cluster
+        /// How long to wait for one of the seed nodes to reply to initial join request.
+        ///
+        /// When this is the first seed node and there is no positive reply from the other
+        /// seed nodes within this timeout it will join itself to bootstrap the cluster.
+        ///
+        /// When this is not the first seed node the join attempts will be performed with
+        /// this interval.
+        member inline this.seed_node_timeout (value: 'Duration) =
+            this.SeedNodeTimeout(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+            
+        /// If a join request fails it will be retried after this period.
+        ///
+        /// Disable join retry by specifying "off".
+        [<CustomOperation("retry_unsuccessful_join_after");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.RetryUnsuccessfulJoinAfter (state: State<Cluster.Target>, value: 'Duration) =
+            durationField "retry-unsuccessful-join-after" value
+            |> State.addWith state Cluster.Target.Cluster
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.RetryUnsuccessfulJoinAfter (state: State<Cluster.Target>, value: bool) =
+            if value then state
+            else
+                switchField "retry-unsuccessful-join-after" value
+                |> State.addWith state Cluster.Target.Cluster
+        /// If a join request fails it will be retried after this period.
+        ///
+        /// Disable join retry by specifying "off".
+        member inline this.retry_unsuccessful_join_after (value: 'Duration) =
+            this.RetryUnsuccessfulJoinAfter(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+        /// If a join request fails it will be retried after this period.
+        ///
+        /// Disable join retry by specifying "off".
+        member this.retry_unsuccessful_join_after (value: bool) =
+            this.RetryUnsuccessfulJoinAfter(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+            
+        /// The joining of given seed nodes will by default be retried indefinitely until
+        /// a successful join. That process can be aborted if unsuccessful by defining this
+        /// timeout. When aborted it will run CoordinatedShutdown, which by default will
+        /// terminate the ActorSystem. CoordinatedShutdown can also be configured to exit
+        /// the JVM. It is useful to define this timeout if the seed-nodes are assembled
+        /// dynamically and a restart with new seed-nodes should be tried after unsuccessful
+        /// attempts.
+        [<CustomOperation("shutdown_after_unsuccessful_join_seed_nodes");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ShutdownAfterUnsuccessfulJoinSeedNodes (state: State<Cluster.Target>, value: 'Duration) =
+            durationField "shutdown-after-unsuccessful-join-seed-nodes" value
+            |> State.addWith state Cluster.Target.Cluster
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ShutdownAfterUnsuccessfulJoinSeedNodes (state: State<Cluster.Target>, value: bool) =
+            if value then state
+            else
+                switchField "shutdown-after-unsuccessful-join-seed-nodes" value
+                |> State.addWith state Cluster.Target.Cluster
+        /// The joining of given seed nodes will by default be retried indefinitely until
+        /// a successful join. That process can be aborted if unsuccessful by defining this
+        /// timeout. When aborted it will run CoordinatedShutdown, which by default will
+        /// terminate the ActorSystem. CoordinatedShutdown can also be configured to exit
+        /// the JVM. It is useful to define this timeout if the seed-nodes are assembled
+        /// dynamically and a restart with new seed-nodes should be tried after unsuccessful
+        /// attempts.
+        member inline this.shutdown_after_unsuccessful_join_seed_nodes (value: 'Duration) =
+            this.ShutdownAfterUnsuccessfulJoinSeedNodes(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+        /// The joining of given seed nodes will by default be retried indefinitely until
+        /// a successful join. That process can be aborted if unsuccessful by defining this
+        /// timeout. When aborted it will run CoordinatedShutdown, which by default will
+        /// terminate the ActorSystem. CoordinatedShutdown can also be configured to exit
+        /// the JVM. It is useful to define this timeout if the seed-nodes are assembled
+        /// dynamically and a restart with new seed-nodes should be tried after unsuccessful
+        /// attempts.
+        member this.shutdown_after_unsuccessful_join_seed_nodes (value: bool) =
+            this.ShutdownAfterUnsuccessfulJoinSeedNodes(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+            
+        /// Should the 'leader' in the cluster be allowed to automatically mark
+        /// unreachable nodes as DOWN after a configured time of unreachability?
+        /// Using auto-down implies that two separate clusters will automatically be
+        /// formed in case of network partition.
+        ///
+        /// Disable with "off" or specify a duration to enable auto-down.
+        ///
+        /// If a downing-provider-class is configured this setting is ignored.
+        [<CustomOperation("auto_down_unreachable_after");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.AutoDownUnreachableAfter (state: State<Cluster.Target>, value: 'Duration) =
+            durationField "auto-down-unreachable-after" value
+            |> State.addWith state Cluster.Target.Cluster
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AutoDownUnreachableAfter (state: State<Cluster.Target>, value: bool) = 
+            if value then state
+            else
+                switchField "auto-down-unreachable-after" value
+                |> State.addWith state Cluster.Target.Cluster
+        /// Should the 'leader' in the cluster be allowed to automatically mark
+        /// unreachable nodes as DOWN after a configured time of unreachability?
+        /// Using auto-down implies that two separate clusters will automatically be
+        /// formed in case of network partition.
+        ///
+        /// Disable with "off" or specify a duration to enable auto-down.
+        ///
+        /// If a downing-provider-class is configured this setting is ignored.
+        member inline this.auto_down_unreachable_after (value: 'Duration) =
+            this.AutoDownUnreachableAfter(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+        /// Should the 'leader' in the cluster be allowed to automatically mark
+        /// unreachable nodes as DOWN after a configured time of unreachability?
+        /// Using auto-down implies that two separate clusters will automatically be
+        /// formed in case of network partition.
+        ///
+        /// Disable with "off" or specify a duration to enable auto-down.
+        ///
+        /// If a downing-provider-class is configured this setting is ignored.
+        member this.auto_down_unreachable_after (value: bool) =
+            this.AutoDownUnreachableAfter(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+            
+        /// Time margin after which shards or singletons that belonged to a downed/removed
+        /// partition are created in surviving partition. The purpose of this margin is that
+        /// in case of a network partition the persistent actors in the non-surviving partitions
+        /// must be stopped before corresponding persistent actors are started somewhere else.
+        /// This is useful if you implement downing strategies that handle network partitions,
+        /// e.g. by keeping the larger side of the partition and shutting down the smaller side.
+        /// It will not add any extra safety for auto-down-unreachable-after, since that is not
+        /// handling network partitions.
+        ///
+        /// Disable with "off" or specify a duration to enable.
+        [<CustomOperation("down_removal_margin");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.DownRemovalMargin (state: State<Cluster.Target>, value: 'Duration) =
+            durationField "down-removal-margin" value
+            |> State.addWith state Cluster.Target.Cluster
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.DownRemovalMargin (state: State<Cluster.Target>, value: bool) =
+            if value then state
+            else
+                switchField "down-removal-margin" value
+                |> State.addWith state Cluster.Target.Cluster
+        /// Time margin after which shards or singletons that belonged to a downed/removed
+        /// partition are created in surviving partition. The purpose of this margin is that
+        /// in case of a network partition the persistent actors in the non-surviving partitions
+        /// must be stopped before corresponding persistent actors are started somewhere else.
+        /// This is useful if you implement downing strategies that handle network partitions,
+        /// e.g. by keeping the larger side of the partition and shutting down the smaller side.
+        /// It will not add any extra safety for auto-down-unreachable-after, since that is not
+        /// handling network partitions.
+        ///
+        /// Disable with "off" or specify a duration to enable.
+        member inline this.down_removal_margin (value: 'Duration) =
+            this.DownRemovalMargin(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+        /// Time margin after which shards or singletons that belonged to a downed/removed
+        /// partition are created in surviving partition. The purpose of this margin is that
+        /// in case of a network partition the persistent actors in the non-surviving partitions
+        /// must be stopped before corresponding persistent actors are started somewhere else.
+        /// This is useful if you implement downing strategies that handle network partitions,
+        /// e.g. by keeping the larger side of the partition and shutting down the smaller side.
+        /// It will not add any extra safety for auto-down-unreachable-after, since that is not
+        /// handling network partitions.
+        ///
+        /// Disable with "off" or specify a duration to enable.
+        member this.down_removal_margin (value: bool) =
+            this.DownRemovalMargin(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+            
+        /// Pluggable support for downing of nodes in the cluster.
+        ///
+        /// If this setting is left empty behaviour will depend on 'auto-down-unreachable' in the following ways:
+        ///
+        /// * if it is 'off' the `NoDowning` provider is used and no automatic downing will be performed
+        ///
+        /// * if it is set to a duration the `AutoDowning` provider is with the configured downing duration
+        ///
+        /// If specified the value must be the fully qualified class name of a subclass of
+        /// `akka.cluster.DowningProvider` having a public one argument constructor accepting an `ActorSystem`
+        [<CustomOperation("downing_provider_class");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.DowningProviderClass (state: State<Cluster.Target>, x: string) =
+            quotedField "downing-provider-class" x
+            |> State.addWith state Cluster.Target.Cluster
+        /// Pluggable support for downing of nodes in the cluster.
+        ///
+        /// If this setting is left empty behaviour will depend on 'auto-down-unreachable' in the following ways:
+        ///
+        /// * if it is 'off' the `NoDowning` provider is used and no automatic downing will be performed
+        ///
+        /// * if it is set to a duration the `AutoDowning` provider is with the configured downing duration
+        ///
+        /// If specified the value must be the fully qualified class name of a subclass of
+        /// `akka.cluster.DowningProvider` having a public one argument constructor accepting an `ActorSystem`
+        member this.downing_provider_class value =
+            this.DowningProviderClass(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+        
+        /// If this is set to "off", the leader will not move 'Joining' members to 'Up' during a network
+        /// split. This feature allows the leader to accept 'Joining' members to be 'WeaklyUp'
+        /// so they become part of the cluster even during a network split. The leader will
+        /// move `Joining` members to 'WeaklyUp' after 3 rounds of 'leader-actions-interval'
+        /// without convergence.
+        ///
+        /// The leader will move 'WeaklyUp' members to 'Up' status once convergence has been reached.
+        [<CustomOperation("allow_weakly_up_members");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AllowWeaklyUpMembers (state: State<Cluster.Target>, value: bool) = 
+            switchField "allow-weakly-up-members" value
+            |> State.addWith state Cluster.Target.Cluster
+        /// If this is set to "off", the leader will not move 'Joining' members to 'Up' during a network
+        /// split. This feature allows the leader to accept 'Joining' members to be 'WeaklyUp'
+        /// so they become part of the cluster even during a network split. The leader will
+        /// move `Joining` members to 'WeaklyUp' after 3 rounds of 'leader-actions-interval'
+        /// without convergence.
+        ///
+        /// The leader will move 'WeaklyUp' members to 'Up' status once convergence has been reached.
+        member this.allow_weakly_up_members value =
+            this.AllowWeaklyUpMembers(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+        
+        /// The roles of this member. List of strings, e.g. roles = ["A", "B"].
+        ///
+        /// The roles are part of the membership information and can be used by
+        /// routers or other services to distribute work to certain member types,
+        /// e.g. front-end and back-end nodes.
+        [<CustomOperation("roles");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Roles (state: State<Cluster.Target>, xs: string list) =
+            listField "roles" xs
+            |> State.addWith state Cluster.Target.Cluster
+        /// The roles of this member. List of strings, e.g. roles = ["A", "B"].
+        ///
+        /// The roles are part of the membership information and can be used by
+        /// routers or other services to distribute work to certain member types,
+        /// e.g. front-end and back-end nodes.
+        member this.roles value =
+            this.Roles(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+
+        /// Application version of the deployment. Used by rolling update features
+        /// to distinguish between old and new nodes. The typical convention is to use
+        /// 3 digit version numbers `major.minor.patch`, but 1 or two digits are also
+        /// supported.
+        ///
+        /// If no `.` is used it is interpreted as a single digit version number or as
+        /// plain alphanumeric if it couldn't be parsed as a number.
+        ///
+        /// It may also have a qualifier at the end for 2 or 3 digit version numbers such
+        /// as "1.2-RC1".
+        /// For 1 digit with qualifier, 1-RC1, it is interpreted as plain alphanumeric.
+        [<CustomOperation("app_version");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AppVersion (state: State<Cluster.Target>, major: int, minor: int, patch: int) = 
+            sprintf "version = %i.%i.%i" major minor patch
+            |> State.addWith state Cluster.Target.Cluster
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AppVersion (state: State<Cluster.Target>, major: int, minor: int, patch: int, qualifier: string) = 
+            sprintf "version = %i.%i.%i-%s" major minor patch qualifier
+            |> State.addWith state Cluster.Target.Cluster
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AppVersion (state: State<Cluster.Target>, major: int, minor: int) = 
+            sprintf "version = %i.%i" major minor
+            |> State.addWith state Cluster.Target.Cluster
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AppVersion (state: State<Cluster.Target>, major: int, minor: int, qualifier: string) = 
+            sprintf "version = %i.%i-%s" major minor qualifier
+            |> State.addWith state Cluster.Target.Cluster
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AppVersion (state: State<Cluster.Target>, major: int) = 
+            sprintf "version = %i" major
+            |> State.addWith state Cluster.Target.Cluster
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AppVersion (state: State<Cluster.Target>, major: int, qualifier: string) = 
+            sprintf "version = %i-%s" major qualifier
+            |> State.addWith state Cluster.Target.Cluster
+        /// Application version of the deployment. Used by rolling update features
+        /// to distinguish between old and new nodes. The typical convention is to use
+        /// 3 digit version numbers `major.minor.patch`, but 1 or two digits are also
+        /// supported.
+        ///
+        /// If no `.` is used it is interpreted as a single digit version number or as
+        /// plain alphanumeric if it couldn't be parsed as a number.
+        ///
+        /// It may also have a qualifier at the end for 2 or 3 digit version numbers such
+        /// as "1.2-RC1".
+        /// For 1 digit with qualifier, 1-RC1, it is interpreted as plain alphanumeric.
+        member this.app_version (major: int, minor: int, patch: int) =
+            this.AppVersion(State.create Cluster.Target.Cluster [], major, minor, patch)
+            |> this.Run
+        /// Application version of the deployment. Used by rolling update features
+        /// to distinguish between old and new nodes. The typical convention is to use
+        /// 3 digit version numbers `major.minor.patch`, but 1 or two digits are also
+        /// supported.
+        ///
+        /// If no `.` is used it is interpreted as a single digit version number or as
+        /// plain alphanumeric if it couldn't be parsed as a number.
+        ///
+        /// It may also have a qualifier at the end for 2 or 3 digit version numbers such
+        /// as "1.2-RC1".
+        /// For 1 digit with qualifier, 1-RC1, it is interpreted as plain alphanumeric.
+        member this.app_version (major: int, minor: int, patch: int, qualifier: string) =
+            this.AppVersion(State.create Cluster.Target.Cluster [], major, minor, patch, qualifier)
+            |> this.Run
+        /// Application version of the deployment. Used by rolling update features
+        /// to distinguish between old and new nodes. The typical convention is to use
+        /// 3 digit version numbers `major.minor.patch`, but 1 or two digits are also
+        /// supported.
+        ///
+        /// If no `.` is used it is interpreted as a single digit version number or as
+        /// plain alphanumeric if it couldn't be parsed as a number.
+        ///
+        /// It may also have a qualifier at the end for 2 or 3 digit version numbers such
+        /// as "1.2-RC1".
+        /// For 1 digit with qualifier, 1-RC1, it is interpreted as plain alphanumeric.
+        member this.app_version (major: int, minor: int) =
+            this.AppVersion(State.create Cluster.Target.Cluster [], major, minor)
+            |> this.Run
+        /// Application version of the deployment. Used by rolling update features
+        /// to distinguish between old and new nodes. The typical convention is to use
+        /// 3 digit version numbers `major.minor.patch`, but 1 or two digits are also
+        /// supported.
+        ///
+        /// If no `.` is used it is interpreted as a single digit version number or as
+        /// plain alphanumeric if it couldn't be parsed as a number.
+        ///
+        /// It may also have a qualifier at the end for 2 or 3 digit version numbers such
+        /// as "1.2-RC1".
+        /// For 1 digit with qualifier, 1-RC1, it is interpreted as plain alphanumeric.
+        member this.app_version (major: int, minor: int, qualifier: string) =
+            this.AppVersion(State.create Cluster.Target.Cluster [], major, minor, qualifier)
+            |> this.Run
+        /// Application version of the deployment. Used by rolling update features
+        /// to distinguish between old and new nodes. The typical convention is to use
+        /// 3 digit version numbers `major.minor.patch`, but 1 or two digits are also
+        /// supported.
+        ///
+        /// If no `.` is used it is interpreted as a single digit version number or as
+        /// plain alphanumeric if it couldn't be parsed as a number.
+        ///
+        /// It may also have a qualifier at the end for 2 or 3 digit version numbers such
+        /// as "1.2-RC1".
+        /// For 1 digit with qualifier, 1-RC1, it is interpreted as plain alphanumeric.
+        member this.app_version (major: int) =
+            this.AppVersion(State.create Cluster.Target.Cluster [], major)
+            |> this.Run
+        /// Application version of the deployment. Used by rolling update features
+        /// to distinguish between old and new nodes. The typical convention is to use
+        /// 3 digit version numbers `major.minor.patch`, but 1 or two digits are also
+        /// supported.
+        ///
+        /// If no `.` is used it is interpreted as a single digit version number or as
+        /// plain alphanumeric if it couldn't be parsed as a number.
+        ///
+        /// It may also have a qualifier at the end for 2 or 3 digit version numbers such
+        /// as "1.2-RC1".
+        /// For 1 digit with qualifier, 1-RC1, it is interpreted as plain alphanumeric.
+        member this.app_version (major: int, qualifier: string) =
+            this.AppVersion(State.create Cluster.Target.Cluster [], major, qualifier)
+            |> this.Run
+        
+        /// Run the coordinated shutdown from phase 'cluster-shutdown' when the cluster
+        /// is shutdown for other reasons than when leaving, e.g. when downing. This
+        /// will terminate the ActorSystem when the cluster extension is shutdown.
+        [<CustomOperation("run_coordinated_shutdown_when_down");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.RunCoordinatedShutdownWhenDown (state: State<Cluster.Target>, value: bool) = 
+            switchField "run-coordinated-shutdown-when-down" value
+            |> State.addWith state Cluster.Target.Cluster
+        /// Run the coordinated shutdown from phase 'cluster-shutdown' when the cluster
+        /// is shutdown for other reasons than when leaving, e.g. when downing. This
+        /// will terminate the ActorSystem when the cluster extension is shutdown.
+        member this.run_coordinated_shutdown_when_down value =
+            this.RunCoordinatedShutdownWhenDown(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+        
+        /// Minimum required number of members before the leader changes member status
+        /// of 'Joining' members to 'Up'. Typically used together with
+        /// 'Cluster.registerOnMemberUp' to defer some action, such as starting actors,
+        /// until the cluster has reached a certain size.
+        [<CustomOperation("min_nr_of_members");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MinNrOfMembers (state: State<Cluster.Target>, value: int) =
+            positiveField "min-nr-of-members" value
+            |> State.addWith state Cluster.Target.Cluster
+        /// Minimum required number of members before the leader changes member status
+        /// of 'Joining' members to 'Up'. Typically used together with
+        /// 'Cluster.registerOnMemberUp' to defer some action, such as starting actors,
+        /// until the cluster has reached a certain size.
+        member this.min_nr_of_members value =
+            this.MinNrOfMembers(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+            
+        /// Enable/disable info level logging of cluster events
+        [<CustomOperation("log_info");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.LogInfo (state: State<Cluster.Target>, value: bool) = 
+            switchField "log-info" value
+            |> State.addWith state Cluster.Target.Cluster
+        /// Enable/disable info level logging of cluster events
+        member this.log_info value =
+            this.LogInfo(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+        
+        /// Enable/disable verbose info-level logging of cluster events
+        /// for temporary troubleshooting. Defaults to 'off'.
+        [<CustomOperation("log_info_verbose");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.LogInfoVerbose (state: State<Cluster.Target>, value: bool) = 
+            switchField "log-info-verbose" value
+            |> State.addWith state Cluster.Target.Cluster
+        /// Enable/disable verbose info-level logging of cluster events
+        /// for temporary troubleshooting. Defaults to 'off'.
+        member this.log_info_verbose value =
+            this.LogInfoVerbose(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+        
+        /// How long should the node wait before starting the periodic tasks
+        /// maintenance tasks?
+        [<CustomOperation("periodic_tasks_initial_delay");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.PeriodicTasksInitialDelay (state: State<Cluster.Target>, value: 'Duration) =
+            durationField "periodic-tasks-initial-delay" value
+            |> State.addWith state Cluster.Target.Cluster
+        /// How long should the node wait before starting the periodic tasks
+        /// maintenance tasks?
+        member inline this.periodic_tasks_initial_delay (value: 'Duration) =
+            this.PeriodicTasksInitialDelay(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+            
+        /// How often should the node send out gossip information?
+        [<CustomOperation("gossip_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.GossipInterval (state: State<Cluster.Target>, value: 'Duration) =
+            durationField "gossip-interval" value
+            |> State.addWith state Cluster.Target.Cluster
+        /// How often should the node send out gossip information?
+        member inline this.gossip_interval (value: 'Duration) =
+            this.GossipInterval(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+            
+        /// discard incoming gossip messages if not handled within this duration
+        [<CustomOperation("gossip_time_to_live");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.GossipTimeToLive (state: State<Cluster.Target>, value: 'Duration) =
+            durationField "gossip-time-to-live" value
+            |> State.addWith state Cluster.Target.Cluster
+        /// discard incoming gossip messages if not handled within this duration
+        member inline this.gossip_time_to_live (value: 'Duration) =
+            this.GossipTimeToLive(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+            
+        /// How often should the leader perform maintenance tasks?
+        [<CustomOperation("leader_actions_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.LeaderActionsInterval (state: State<Cluster.Target>, value: 'Duration) =
+            durationField "leader-actions-interval" value
+            |> State.addWith state Cluster.Target.Cluster
+        /// How often should the leader perform maintenance tasks?
+        member inline this.leader_actions_interval (value: 'Duration) =
+            this.LeaderActionsInterval(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+        
+        /// How often should the node move nodes, marked as unreachable by the failure
+        /// detector, out of the membership ring?
+        [<CustomOperation("unreachable_nodes_reaper_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.UnreachableNodesReaperInterval (state: State<Cluster.Target>, value: 'Duration) =
+            durationField "unreachable-nodes-reaper-interval" value
+            |> State.addWith state Cluster.Target.Cluster
+        /// How often should the node move nodes, marked as unreachable by the failure
+        /// detector, out of the membership ring?
+        member inline this.unreachable_nodes_reaper_interval (value: 'Duration) =
+            this.UnreachableNodesReaperInterval(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+            
+        /// How often the current internal stats should be published.
+        /// A value of 0s can be used to always publish the stats, when it happens.
+        ///
+        /// Disable with "off".
+        [<CustomOperation("publish_stats_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.PublishStatsInterval (state: State<Cluster.Target>, value: 'Duration) =
+            durationField "publish-stats-interval" value
+            |> State.addWith state Cluster.Target.Cluster
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member this.PublishStatsInterval (state: State<Cluster.Target>, value: bool) =
+            if value then this.PublishStatsInterval(state, 0<s>)
+            else 
+                switchField "publish-stats-interval" value
+                |> State.addWith state Cluster.Target.Cluster
+        /// How often the current internal stats should be published.
+        /// A value of 0s can be used to always publish the stats, when it happens.
+        ///
+        /// Disable with "off".
+        member inline this.publish_stats_interval (value: 'Duration) =
+            this.PublishStatsInterval(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+        /// How often the current internal stats should be published.
+        /// A value of 0s can be used to always publish the stats, when it happens.
+        ///
+        /// Disable with "off".
+        member this.publish_stats_interval (value: bool) =
+            this.PublishStatsInterval(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+        
+        /// The id of the dispatcher to use for cluster actors.
+        ///
+        /// If not specified, the internal dispatcher is used.
+        ///
+        /// If specified you need to define the settings of the actual dispatcher.
+        [<CustomOperation("use_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.UseDispatcher (state: State<Cluster.Target>, x: string) =
+            quotedField "use-dispatcher" x
+            |> State.addWith state Cluster.Target.Cluster
+        /// The id of the dispatcher to use for cluster actors.
+        ///
+        /// If not specified, the internal dispatcher is used.
+        ///
+        /// If specified you need to define the settings of the actual dispatcher.
+        member this.use_dispatcher value =
+            this.UseDispatcher(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+        
+        /// Gossip to random node with newer or older state information, if any with
+        /// this probability. Otherwise Gossip to any random live node.
+        ///
+        /// Probability value is between 0.0 and 1.0. 0.0 means never, 1.0 means always.
+        [<CustomOperation("gossip_different_view_probability");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.GossipDifferentViewProbability (state: State<Cluster.Target>, value: float) =
+            let fieldName = "gossip-different-view-probability"
+
+            if value > 1. || value < 0. then 
+                failwithf "Field %s must have a value between 0.0 and 1.0. You provided: %f" 
+                    fieldName value
+            else positiveFieldf fieldName value
+            |> State.addWith state Cluster.Target.Cluster
+        /// Gossip to random node with newer or older state information, if any with
+        /// this probability. Otherwise Gossip to any random live node.
+        ///
+        /// Probability value is between 0.0 and 1.0. 0.0 means never, 1.0 means always.
+        member this.gossip_different_view_probability value =
+            this.GossipDifferentViewProbability(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+        
+        /// Reduced the above probability when the number of nodes in the cluster
+        /// greater than this value.
+        [<CustomOperation("reduce_gossip_different_view_probability");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ReduceGossipDifferentViewProbability (state: State<Cluster.Target>, value: int) =
+            positiveField "reduce-gossip-different-view-probability" value
+            |> State.addWith state Cluster.Target.Cluster
+        /// Reduced the above probability when the number of nodes in the cluster
+        /// greater than this value.
+        member this.reduce_gossip_different_view_probability value =
+            this.ReduceGossipDifferentViewProbability(State.create Cluster.Target.Cluster [], value)
+            |> this.Run
+
+        // Akka.Actor.Deployment.Default.Cluster
+
+        /// Enable cluster aware router that deploys to nodes in the cluster
+        [<CustomOperation("enabled");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Enabled (state: State<Cluster.Target>, value: bool) = 
+            switchField "enabled" value
+            |> State.addWith state Cluster.Target.DeploymentDefault
+        /// Enable cluster aware router that deploys to nodes in the cluster
+        member this.enabled value =
+            this.Enabled(State.create Cluster.Target.DeploymentDefault [], value)
+            |> this.Run
+            
+        /// Maximum number of routees that will be deployed on each cluster
+        /// member node.
+        ///
+        /// Note that max-total-nr-of-instances defines total number of routees, but
+        /// number of routees per node will not be exceeded, i.e. if you
+        /// define max-total-nr-of-instances = 50 and max-nr-of-instances-per-node = 2
+        /// it will deploy 2 routees per new member in the cluster, up to
+        /// 25 members.
+        [<CustomOperation("max_nr_of_instances_per_node");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MaxNrOfInstancesPerNode (state: State<Cluster.Target>, value: int) =
+            positiveField "max-nr-of-instances-per-node" value
+            |> State.addWith state Cluster.Target.DeploymentDefault
+        /// Maximum number of routees that will be deployed on each cluster
+        /// member node.
+        ///
+        /// Note that max-total-nr-of-instances defines total number of routees, but
+        /// number of routees per node will not be exceeded, i.e. if you
+        /// define max-total-nr-of-instances = 50 and max-nr-of-instances-per-node = 2
+        /// it will deploy 2 routees per new member in the cluster, up to
+        /// 25 members.
+        member this.max_nr_of_instances_per_node value =
+            this.MaxNrOfInstancesPerNode(State.create Cluster.Target.DeploymentDefault [], value)
+            |> this.Run
+        
+        /// Maximum number of routees that will be deployed, in total
+        /// on all nodes. See also description of max-nr-of-instances-per-node.
+        ///
+        /// For backwards compatibility reasons, nr-of-instances
+        /// has the same purpose as max-total-nr-of-instances for cluster
+        /// aware routers and nr-of-instances (if defined by user) takes
+        /// precedence over max-total-nr-of-instances.
+        [<CustomOperation("max_total_nr_of_instances");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MaxTotalNrOfInstances (state: State<Cluster.Target>, value: int) =
+            positiveField "max-total-nr-of-instances" value
+            |> State.addWith state Cluster.Target.DeploymentDefault
+        /// Maximum number of routees that will be deployed, in total
+        /// on all nodes. See also description of max-nr-of-instances-per-node.
+        ///
+        /// For backwards compatibility reasons, nr-of-instances
+        /// has the same purpose as max-total-nr-of-instances for cluster
+        /// aware routers and nr-of-instances (if defined by user) takes
+        /// precedence over max-total-nr-of-instances.
+        member this.max_total_nr_of_instances value =
+            this.MaxTotalNrOfInstances(State.create Cluster.Target.DeploymentDefault [], value)
+            |> this.Run
+        
+        /// Defines if routees are allowed to be located on the same node as
+        /// the head router actor, or only on remote nodes.
+        ///
+        /// Useful for master-worker scenario where all routees are remote.
+        [<CustomOperation("allow_local_routees");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AllowLocalRoutees (state: State<Cluster.Target>, value: bool) = 
+            switchField "allow-local-routees" value
+            |> State.addWith state Cluster.Target.DeploymentDefault
+        /// Defines if routees are allowed to be located on the same node as
+        /// the head router actor, or only on remote nodes.
+        ///
+        /// Useful for master-worker scenario where all routees are remote.
+        member this.allow_local_routees value =
+            this.AllowLocalRoutees(State.create Cluster.Target.DeploymentDefault [], value)
+            |> this.Run
+        
+        /// Use members with specified role, or all members if undefined or empty.
+        [<CustomOperation("use_role")>]
+        member _.UseRole (state: State<Cluster.Target>, value: string) =
+            quotedField "use-role" value
+            |> State.addWith state Cluster.Target.DeploymentDefault
+        /// Use members with specified role, or all members if undefined or empty.
+        member this.use_role value =
+            this.UseRole(State.create Cluster.Target.DeploymentDefault [], value)
+            |> this.Run
+
+        // Pathing
+        
+        member _.debug =
+            { new DebugBuilder<'T>() with
+                member _.Run (state: State<Debug.Target>) : Akka.Shared.Field<'T> =
+                    fun _ -> pathObjExpr 5 "debug" state.Fields }
+
+        /// Cluster metrics extension.
+        ///
+        /// Provides periodic statistics collection and publication throughout the cluster.
+        member _.metrics =
+            { new MetricsBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 3 "metrics" state }
+
+        /// Settings for the DistributedPubSub extension
+        member _.pub_sub =
+            { new PubSubBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 3 "pub-sub" state }
+
+        /// Settings for the ClusterClient
+        member _.client =
+            { new ClientBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 3 "client" state }
+
+        member _.role =
+            { new RoleBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 3 "role" state }
+
+        /// Settings for the Phi accrual failure detector (http://ddg.jaist.ac.jp/pub/HDY+04.pdf
+        /// [Hayashibara et al]) used by the cluster subsystem to detect unreachable
+        /// members.
+        member _.failure_detector =
+            { new FailureDetectorBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 3 "failure-detector" state }
+
+        member _.split_brain_resolver =
+            { new SplitBrainResolverBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 3 "split-brain-resolver" state }
+
+        member _.singleton_proxy =
+            { new SingletonProxyBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 3 "singleton-proxy" state }
+        
+        member _.singleton =
+            { new SingletonBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 3 "singleton" state }
+
+    let cluster =
+        let path = "cluster"
+
+        { new ClusterBuilder<Akka.Shared.Cluster.Field>(Akka.Shared.Cluster.Field, path) with
+            member _.Run (state: State<Cluster.Target>) : Akka.Shared.Field<Akka.Shared.Cluster.Field> =
+                fun indent ->
+                    objExpr "cluster" indent state.Fields
+                    |> Akka.Shared.Cluster.Field }

--- a/src/Akkling.Hocon/Shared.Debug.fs
+++ b/src/Akkling.Hocon/Shared.Debug.fs
@@ -1,0 +1,192 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Debug =
+    open MarkerClasses
+    open InternalHocon
+    open SharedInternal
+    open System.ComponentModel
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    module Debug =
+        [<RequireQualifiedAccess>]
+        type Target =
+            | Any
+            | Actor
+            | Cluster
+            | Materializer
+        
+        [<RequireQualifiedAccess>]
+        module Target =
+            let merge (target1: Target) (target2: Target) =
+                match target1, target2 with
+                | Target.Any, _
+                | _, Target.Any -> Some target1
+                | _, _ when target1 = target2 -> Some target1
+                | _ -> None
+
+        [<RequireQualifiedAccess>]
+        module State =
+            let create = State.create Target.Any
+    
+    [<AbstractClass>]
+    type DebugBuilder<'T when 'T :> IField> () =
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        abstract Run : State<Debug.Target> -> Akka.Shared.Field<'T>
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: string) = Debug.State.create [x]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (a: unit) = Debug.State.create []
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Combine (state1: State<Debug.Target>, state2: State<Debug.Target>) : State<Debug.Target> =
+            let fields = state1.Fields @ state2.Fields
+
+            match Debug.Target.merge state1.Target state2.Target with
+            | Some target -> { Target = target; Fields = fields }
+            | None -> 
+                failwithf "Debug fields mismatch found was given:%s%A"
+                    System.Environment.NewLine fields
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Zero () = Debug.State.create []
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Delay f = f()
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member this.For (state: State<Debug.Target>, f: unit -> State<Debug.Target>) = this.Combine(state, f())
+
+        /// Enable DEBUG logging of all AutoReceiveMessages (Kill, PoisonPill et.c.)
+        [<CustomOperation("autoreceive");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AutoReceive (state: State<Debug.Target>, value: bool) = 
+            switchField "autoreceive" value
+            |> State.addWith state Debug.Target.Actor
+        /// Enable DEBUG logging of all AutoReceiveMessages (Kill, PoisonPill et.c.)
+        member this.autoreceive value =
+            this.AutoReceive(State.create Debug.Target.Actor [], value)
+            |> this.Run
+        
+        /// Enable DEBUG logging of subscription changes on the eventStream
+        [<CustomOperation("event_stream");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.EventStream (state: State<Debug.Target>, value: bool) = 
+            switchField "event-stream" value
+            |> State.addWith state Debug.Target.Actor
+        /// Enable DEBUG logging of subscription changes on the eventStream
+        member this.event_stream value =
+            this.EventStream(State.create Debug.Target.Actor [], value)
+            |> this.Run
+            
+        /// Enable DEBUG logging of all LoggingFSMs for events, transitions and timers
+        [<CustomOperation("fsm");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Fsm (state: State<Debug.Target>, value: bool) = 
+            switchField "fsm" value
+            |> State.addWith state Debug.Target.Actor
+        /// Enable DEBUG logging of all LoggingFSMs for events, transitions and timers
+        member this.fsm value =
+            this.Fsm(State.create Debug.Target.Actor [], value)
+            |> this.Run
+            
+        /// Enable DEBUG logging of actor lifecycle changes
+        [<CustomOperation("lifecycle");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Lifecycle (state: State<Debug.Target>, value: bool) = 
+            switchField "lifecycle" value
+            |> State.addWith state Debug.Target.Actor
+        /// Enable DEBUG logging of actor lifecycle changes
+        member this.lifecycle value =
+            this.Lifecycle(State.create Debug.Target.Actor [], value)
+            |> this.Run
+            
+        /// Enable function of Actor.loggable(), which is to log any received message
+        /// at DEBUG level, see the “Testing Actor Systems” section of the Akka
+        /// Documentation at http://akka.io/docs
+        [<CustomOperation("receive");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Receive (state: State<Debug.Target>, value: bool) = 
+            switchField "receive" value
+            |> State.addWith state Debug.Target.Actor
+        /// Enable function of Actor.loggable(), which is to log any received message
+        /// at DEBUG level, see the “Testing Actor Systems” section of the Akka
+        /// Documentation at http://akka.io/docs
+        member this.receive value =
+            this.Receive(State.create Debug.Target.Actor [], value)
+            |> this.Run
+
+        /// Enable WARN logging of misconfigured routers
+        [<CustomOperation("router_misconfiguration");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.RouterMisconfiguration (state: State<Debug.Target>, value: bool) = 
+            switchField "router-misconfiguration" value
+            |> State.addWith state Debug.Target.Actor
+        /// Enable WARN logging of misconfigured routers
+        member this.router_misconfiguration value =
+            this.RouterMisconfiguration(State.create Debug.Target.Actor [], value)
+            |> this.Run
+
+        /// Enable DEBUG logging of unhandled messages
+        [<CustomOperation("unhandled");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Unhandled (state: State<Debug.Target>, value: bool) = 
+            switchField "unhandled" value
+            |> State.addWith state Debug.Target.Actor
+        /// Enable DEBUG logging of unhandled messages
+        member this.unhandled value =
+            this.Unhandled(State.create Debug.Target.Actor [], value)
+            |> this.Run
+
+        // Akka.Cluster
+
+        /// Log heartbeat events (very verbose, useful mostly when debugging heartbeating issues)
+        [<CustomOperation("verbose_heartbeat_logging");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.VerboseHeartbeatLogging (state: State<Debug.Target>, value: bool) = 
+            switchField "verbose-heartbeat-logging" value
+            |> State.addWith state Debug.Target.Cluster
+        /// Log heartbeat events (very verbose, useful mostly when debugging heartbeating issues)
+        member this.verbose_heartbeat_logging value =
+            this.VerboseHeartbeatLogging(State.create Debug.Target.Cluster [], value)
+            |> this.Run
+        
+        /// Log gossip merge events (very verbose, useful when debugging convergence issues)
+        [<CustomOperation("verbose_receive_gossip_logging");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.VerboseReceiveGossipLogging (state: State<Debug.Target>, value: bool) = 
+            switchField "verbose-receive-gossip-logging" value
+            |> State.addWith state Debug.Target.Cluster
+        /// Log gossip merge events (very verbose, useful when debugging convergence issues)
+        member this.verbose_receive_gossip_logging value =
+            this.VerboseReceiveGossipLogging(State.create Debug.Target.Cluster [], value)
+            |> this.Run
+
+        // Akka.Streams.Materializer
+
+        /// Enables the fuzzing mode which increases the chance of race conditions
+        /// by aggressively reordering events and making certain operations more
+        /// concurrent than usual.
+        ///
+        /// This setting is for testing purposes, NEVER enable this in a production
+        /// environment!
+        ///
+        /// To get the best results, try combining this setting with a throughput
+        /// of 1 on the corresponding dispatchers.
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        [<CustomOperation("fuzzing_mode");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.FuzzingMode (state: State<Debug.Target>, value: bool) = 
+            switchField "fuzzing-mode" value
+            |> State.addWith state Debug.Target.Materializer
+        /// Enables the fuzzing mode which increases the chance of race conditions
+        /// by aggressively reordering events and making certain operations more
+        /// concurrent than usual.
+        ///
+        /// This setting is for testing purposes, NEVER enable this in a production
+        /// environment!
+        ///
+        /// To get the best results, try combining this setting with a throughput
+        /// of 1 on the corresponding dispatchers.
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        member this.FuzzingMode value =
+            this.VerboseReceiveGossipLogging(State.create Debug.Target.Materializer [], value)
+            |> this.Run
+    
+    let debug =
+        { new DebugBuilder<Akka.Shared.Debug.Field>() with
+            member _.Run (state: State<Debug.Target>) : Akka.Shared.Field<Akka.Shared.Debug.Field> =
+                fun indent ->
+                    objExpr "debug" indent state.Fields
+                    |> Akka.Shared.Debug.Field }

--- a/src/Akkling.Hocon/Shared.Tcp.fs
+++ b/src/Akkling.Hocon/Shared.Tcp.fs
@@ -1,0 +1,723 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Tcp =
+    open MarkerClasses
+    open InternalHocon
+    open SharedInternal
+    open System.ComponentModel
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    module Tcp =
+        [<RequireQualifiedAccess>]
+        type Target =
+            | Any
+            | IO
+            | Remote
+        
+        [<RequireQualifiedAccess>]
+        module Target =
+            let merge (target1: Target) (target2: Target) =
+                match target1, target2 with
+                | Target.Any, _
+                | _, Target.Any -> Some target1
+                | _, _ when target1 = target2 -> Some target1
+                | _ -> None
+
+        [<RequireQualifiedAccess>]
+        module State =
+            let create = State.create Target.Any
+
+    [<AbstractClass>]
+    type TcpBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string) =
+        let pathObjExpr = pathObjExpr mkField path
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        abstract Run : State<Tcp.Target> -> Akka.Shared.Field<'T>
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: string) = Tcp.State.create [x]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.IO.DisabledBufferPool.Field) = State.create Tcp.Target.IO [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.IO.DirectBufferPool.Field) = State.create Tcp.Target.IO [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Remote.Batching.Field) = State.create Tcp.Target.Remote [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Remote.WorkerPool.Field) = State.create Tcp.Target.Remote [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (a: unit) = Tcp.State.create []
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Combine (state1: State<Tcp.Target>, state2: State<Tcp.Target>) : State<Tcp.Target> =
+            let fields = state1.Fields @ state2.Fields
+
+            match Tcp.Target.merge state1.Target state2.Target with
+            | Some target -> { Target = target; Fields = fields }
+            | None -> 
+                failwithf "Tcp fields mismatch found was given:%s%A"
+                    System.Environment.NewLine fields
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Zero () = Tcp.State.create []
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Delay f = f()
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member this.For (state: State<Tcp.Target>, f: unit -> State<Tcp.Target>) = this.Combine(state, f())
+
+        // Akka.IO
+
+        /// A buffer pool used to acquire and release byte buffers from the managed
+        /// heap. Once byte buffer is no longer needed is can be released, landing 
+        /// on the pool again, to be reused later. This way we can reduce a GC pressure
+        /// by reusing the same components instead of recycling them.
+        ///
+        /// NOTE: pooling is disabled by default, to enable use direct-buffer-pool:
+        /// set this field to "akka.io.tcp.direct-buffer-pool"
+        [<CustomOperation("buffer_pool");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.BufferPool (state: State<Tcp.Target>, value: string) =
+            quotedField "buffer-pool" value
+            |> State.addWith state Tcp.Target.IO
+        /// A buffer pool used to acquire and release byte buffers from the managed
+        /// heap. Once byte buffer is no longer needed is can be released, landing 
+        /// on the pool again, to be reused later. This way we can reduce a GC pressure
+        /// by reusing the same components instead of recycling them.
+        ///
+        /// NOTE: pooling is disabled by default, to enable use direct-buffer-pool:
+        /// set this field to "akka.io.tcp.direct-buffer-pool"
+        member this.buffer_pool value =
+            this.BufferPool(State.create Tcp.Target.IO [], value)
+            |> this.Run
+        
+        /// Maximum number of open channels supported by this TCP module; there is
+        /// no intrinsic general limit, this setting is meant to enable DoS
+        /// protection by limiting the number of concurrently connected clients.
+        /// Also note that this is a "soft" limit; in certain cases the implementation
+        /// will accept a few connections more or a few less than the number configured
+        /// here. Must be an integer > 0 or "unlimited".
+        [<CustomOperation("max_channels");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.MaxChannels (state: State<Tcp.Target>, value) =
+            positiveField "max-channels" value
+            |> State.addWith state Tcp.Target.IO
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MaxChannels (state: State<Tcp.Target>, value: Hocon.Unlimited) =
+            quotedField "max-channels" (value.ToString())
+            |> State.addWith state Tcp.Target.IO
+        /// Maximum number of open channels supported by this TCP module; there is
+        /// no intrinsic general limit, this setting is meant to enable DoS
+        /// protection by limiting the number of concurrently connected clients.
+        /// Also note that this is a "soft" limit; in certain cases the implementation
+        /// will accept a few connections more or a few less than the number configured
+        /// here. Must be an integer > 0 or "unlimited".
+        member inline this.max_channels value =
+            positiveField "max-channels" value
+            |> State.add (State.create Tcp.Target.IO [])
+            |> this.Run
+        /// Maximum number of open channels supported by this TCP module; there is
+        /// no intrinsic general limit, this setting is meant to enable DoS
+        /// protection by limiting the number of concurrently connected clients.
+        /// Also note that this is a "soft" limit; in certain cases the implementation
+        /// will accept a few connections more or a few less than the number configured
+        /// here. Must be an integer > 0 or "unlimited".
+        member this.max_channels (value: Hocon.Unlimited) =
+            this.MaxChannels(State.create Tcp.Target.IO [], value)
+            |> this.Run
+        
+        /// When trying to assign a new connection to a selector and the chosen
+        /// selector is at full capacity, retry selector choosing and assignment
+        /// this many times before giving up
+        [<CustomOperation("selector_association_retries");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.SelectorAssociationRetries (state: State<Tcp.Target>, value) =
+            positiveField "selector-association-retries" value
+            |> State.addWith state Tcp.Target.IO
+        /// When trying to assign a new connection to a selector and the chosen
+        /// selector is at full capacity, retry selector choosing and assignment
+        /// this many times before giving up
+        member inline this.selector_association_retries value =
+            this.SelectorAssociationRetries(State.create Tcp.Target.IO [], value)
+            |> this.Run
+        
+        /// The maximum number of connection that are accepted in one go,
+        /// higher numbers decrease latency, lower numbers increase fairness on
+        /// the worker-dispatcher
+        [<CustomOperation("batch_accept_limit");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.BatchAcceptLimit (state: State<Tcp.Target>, value) =
+            positiveField "batch-accept-limit" value
+            |> State.addWith state Tcp.Target.IO
+        /// The maximum number of connection that are accepted in one go,
+        /// higher numbers decrease latency, lower numbers increase fairness on
+        /// the worker-dispatcher
+        member inline this.batch_accept_limit value =
+            this.BatchAcceptLimit(State.create Tcp.Target.IO [], value)
+            |> this.Run
+
+        /// The duration a connection actor waits for a `Register` message from
+        /// its commander before aborting the connection.
+        [<CustomOperation("register_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.RegisterTimeout (state: State<Tcp.Target>, value: 'Duration) =
+            durationField "register-timeout" value
+            |> State.addWith state Tcp.Target.IO
+        /// The duration a connection actor waits for a `Register` message from
+        /// its commander before aborting the connection.
+        member inline this.register_timeout (value: 'Duration) =
+            this.RegisterTimeout(State.create Tcp.Target.IO [], value)
+            |> this.Run
+        
+        /// The maximum number of bytes delivered by a `Received` message. Before
+        /// more data is read from the network the connection actor will try to
+        /// do other work.
+        /// 
+        /// The purpose of this setting is to impose a smaller limit than the 
+        /// configured receive buffer size. When using value 'unlimited' it will
+        /// try to read all from the receive buffer.
+        [<CustomOperation("max_received_message_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.MaxReceivedMessageSize (state: State<Tcp.Target>, value) =
+            positiveField "max-received-message-size" value
+            |> State.addWith state Tcp.Target.IO
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MaxReceivedMessageSize (state: State<Tcp.Target>, value: Hocon.Unlimited) =
+            quotedField "max-received-message-size" (value.ToString())
+            |> State.addWith state Tcp.Target.IO
+        /// The maximum number of bytes delivered by a `Received` message. Before
+        /// more data is read from the network the connection actor will try to
+        /// do other work.
+        /// 
+        /// The purpose of this setting is to impose a smaller limit than the 
+        /// configured receive buffer size. When using value 'unlimited' it will
+        /// try to read all from the receive buffer.
+        member inline this.max_received_message_size value =
+            positiveField "max-received-message-size" value
+            |> State.add (State.create Tcp.Target.IO [])
+            |> this.Run
+        /// The maximum number of bytes delivered by a `Received` message. Before
+        /// more data is read from the network the connection actor will try to
+        /// do other work.
+        /// 
+        /// The purpose of this setting is to impose a smaller limit than the 
+        /// configured receive buffer size. When using value 'unlimited' it will
+        /// try to read all from the receive buffer.
+        member this.max_received_message_size (value: Hocon.Unlimited) =
+            this.MaxReceivedMessageSize(State.create Tcp.Target.IO [], value)
+            |> this.Run
+
+        /// Enable fine grained logging of what goes on inside the implementation.
+        /// Be aware that this may log more than once per message sent to the actors
+        /// of the tcp implementation.
+        [<CustomOperation("trace_logging");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TraceLogging (state: State<Tcp.Target>, value: bool) =
+            switchField "trace-logging" value
+            |> State.addWith state Tcp.Target.IO
+        /// Enable fine grained logging of what goes on inside the implementation.
+        /// Be aware that this may log more than once per message sent to the actors
+        /// of the tcp implementation.
+        member this.trace_logging value =
+            this.TraceLogging(State.create Tcp.Target.IO [], value)
+            |> this.Run
+    
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// to be used for running the select() calls in the selectors
+        [<CustomOperation("selector_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SelectorDispatcher (state: State<Tcp.Target>, value: string) =
+            quotedField "selector-dispatcher" value
+            |> State.addWith state Tcp.Target.IO
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// to be used for running the select() calls in the selectors
+        member this.selector_dispatcher value =
+            this.SelectorDispatcher(State.create Tcp.Target.IO [], value)
+            |> this.Run
+        
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// for the read/write worker actors
+        [<CustomOperation("worker_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.WorkerDispatcher (state: State<Tcp.Target>, value: string) =
+            quotedField "worker-dispatcher" value
+            |> State.addWith state Tcp.Target.IO
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// for the read/write worker actors
+        member this.worker_dispatcher value =
+            this.WorkerDispatcher(State.create Tcp.Target.IO [], value)
+            |> this.Run
+
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// for the selector management actors
+        [<CustomOperation("management_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ManagementDispatcher (state: State<Tcp.Target>, value: string) =
+            quotedField "management-dispatcher" value
+            |> State.addWith state Tcp.Target.IO
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// for the selector management actors
+        member this.management_dispatcher value =
+            this.ManagementDispatcher(State.create Tcp.Target.IO [], value)
+            |> this.Run
+
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// on which file IO tasks are scheduled
+        [<CustomOperation("file_io_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.FileIODispatcher (state: State<Tcp.Target>, value: string) =
+            quotedField "file-io-dispatcher" value
+            |> State.addWith state Tcp.Target.IO
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// on which file IO tasks are scheduled
+        member this.file_io_dispatcher value =
+            this.FileIODispatcher(State.create Tcp.Target.IO [], value)
+            |> this.Run
+    
+        /// The maximum number of bytes (or "unlimited") to transfer in one batch
+        /// when using `WriteFile` command which uses `FileChannel.transferTo` to
+        /// pipe files to a TCP socket. On some OS like Linux `FileChannel.transferTo`
+        /// may block for a long time when network IO is faster than file IO.
+        /// Decreasing the value may improve fairness while increasing may improve
+        /// throughput.
+        [<CustomOperation("file_io_transferTo_limit");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.FileIoTransferToLimit (state: State<Tcp.Target>, value) =
+            positiveField "file-io-transferTo-limit" value
+            |> State.addWith state Tcp.Target.IO
+        /// The maximum number of bytes (or "unlimited") to transfer in one batch
+        /// when using `WriteFile` command which uses `FileChannel.transferTo` to
+        /// pipe files to a TCP socket. On some OS like Linux `FileChannel.transferTo`
+        /// may block for a long time when network IO is faster than file IO.
+        /// Decreasing the value may improve fairness while increasing may improve
+        /// throughput.
+        member inline this.file_io_transferTo_limit value =
+            this.FileIoTransferToLimit(State.create Tcp.Target.IO [], value)
+            |> this.Run
+        
+        /// The number of times to retry the `finishConnect` call after being notified about
+        /// OP_CONNECT. Retries are needed if the OP_CONNECT notification doesn't imply that
+        /// `finishConnect` will succeed, which is the case on Android.
+        [<CustomOperation("finish_connect_retries");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.FinishConnectRetries (state: State<Tcp.Target>, value) =
+            positiveField "finish-connect-retries" value
+            |> State.addWith state Tcp.Target.IO
+        /// The number of times to retry the `finishConnect` call after being notified about
+        /// OP_CONNECT. Retries are needed if the OP_CONNECT notification doesn't imply that
+        /// `finishConnect` will succeed, which is the case on Android.
+        member inline this.finish_connect_retries value =
+            this.FinishConnectRetries(State.create Tcp.Target.IO [], value)
+            |> this.Run
+        
+        /// On Windows connection aborts are not reliably detected unless an OP_READ is
+        /// registered on the selector _after_ the connection has been reset. This
+        /// workaround enables an OP_CONNECT which forces the abort to be visible on Windows.
+        /// Enabling this setting on other platforms than Windows will cause various failures
+        /// and undefined behavior.
+        /// Possible values of this key are on, off and auto where auto will enable the
+        /// workaround if Windows is detected automatically.
+        [<CustomOperation("windows_connection_abort_workaround_enabled");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.WindowsConnectionAbortWorkaroundEnabled (state: State<Tcp.Target>, value: bool) =
+            switchField "windows-connection-abort-workaround-enabled" value
+            |> State.addWith state Tcp.Target.IO
+        /// On Windows connection aborts are not reliably detected unless an OP_READ is
+        /// registered on the selector _after_ the connection has been reset. This
+        /// workaround enables an OP_CONNECT which forces the abort to be visible on Windows.
+        /// Enabling this setting on other platforms than Windows will cause various failures
+        /// and undefined behavior.
+        /// Possible values of this key are on, off and auto where auto will enable the
+        /// workaround if Windows is detected automatically.
+        member this.windows_connection_abort_workaround_enabled value =
+            this.WindowsConnectionAbortWorkaroundEnabled(State.create Tcp.Target.IO [], value)
+            |> this.Run
+        
+        /// Enforce outgoing socket connection to use IPv4 address family. Required in
+        /// scenario when IPv6 is not available, for example in Azure Web App sandbox.
+        /// When set to true it is required to set akka.io.dns.inet-address.use-ipv6 to false
+        /// in cases when DnsEndPoint is used to describe the remote address
+        [<CustomOperation("outgoing_socket_force_ipv4");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.OutgoingSocketForceIpv4 (state: State<Tcp.Target>, value: bool) =
+            boolField "outgoing-socket-force-ipv4" value
+            |> State.addWith state Tcp.Target.IO
+        /// Enforce outgoing socket connection to use IPv4 address family. Required in
+        /// scenario when IPv6 is not available, for example in Azure Web App sandbox.
+        /// When set to true it is required to set akka.io.dns.inet-address.use-ipv6 to false
+        /// in cases when DnsEndPoint is used to describe the remote address
+        member this.outgoing_socket_force_ipv4 value =
+            this.OutgoingSocketForceIpv4(State.create Tcp.Target.IO [], value)
+            |> this.Run
+        
+        // Akka.Remote.DotNetty
+
+        /// The class given here must implement the akka.remote.transport.Transport
+        /// interface and offer a public constructor which takes two arguments:
+        ///
+        ///  1) akka.actor.ExtendedActorSystem
+        ///
+        ///  2) com.typesafe.config.Config
+        [<CustomOperation("transport_class");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TransportClass (state: State<Tcp.Target>, x: string) = 
+            quotedField "transport-class" x
+            |> State.addWith state Tcp.Target.Remote
+        /// The class given here must implement the akka.remote.transport.Transport
+        /// interface and offer a public constructor which takes two arguments:
+        ///
+        ///  1) akka.actor.ExtendedActorSystem
+        ///
+        ///  2) com.typesafe.config.Config
+        member this.transport_class value =
+            this.TransportClass(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+        
+        /// Transport drivers can be augmented with adapters by adding their
+        /// name to the applied-adapters list. The last adapter in the
+        /// list is the adapter immediately above the driver, while
+        /// the first one is the top of the stack below the standard
+        /// Akka protocol 
+        [<CustomOperation("applied_adapters");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AppliedAdapters (state: State<Tcp.Target>, x: string list) = 
+            quotedListField "applied-adapters" x
+            |> State.addWith state Tcp.Target.Remote
+        /// Transport drivers can be augmented with adapters by adding their
+        /// name to the applied-adapters list. The last adapter in the
+        /// list is the adapter immediately above the driver, while
+        /// the first one is the top of the stack below the standard
+        /// Akka protocol 
+        member this.applied_adapters value =
+            this.AppliedAdapters(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Byte order used for network communication. Event thou DotNetty is big-endian
+        /// by default, we need to switch it back to little endian in order to support
+        /// backward compatibility with Helios.
+        [<CustomOperation("byte_order");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ByteOrder (state: State<Tcp.Target>, x: Hocon.ByteOrder) = 
+            quotedField "byte-order" (x.Text)
+            |> State.addWith state Tcp.Target.Remote
+        /// Byte order used for network communication. Event thou DotNetty is big-endian
+        /// by default, we need to switch it back to little endian in order to support
+        /// backward compatibility with Helios.
+        member this.byte_order value =
+            this.ByteOrder(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+        
+        /// The default remote server port clients should connect to.
+        /// Default is 2552 (AKKA), use 0 if you want a random available port
+        /// This port needs to be unique for each actor system on the same machine.
+        [<CustomOperation("port");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.Port (state: State<Tcp.Target>, x) =
+            positiveField "port" x
+            |> State.addWith state Tcp.Target.Remote
+        /// The default remote server port clients should connect to.
+        /// Default is 2552 (AKKA), use 0 if you want a random available port
+        /// This port needs to be unique for each actor system on the same machine.
+        member inline this.port value =
+            this.Port(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Similar in spirit to "public-hostname" setting, this allows Akka.Remote users
+        /// to alias the port they're listening on. The socket will actually listen on the
+        /// "port" setting, but when connecting to other ActorSystems this node will advertise
+        /// itself as being connected to the "public-port". This is helpful when working with 
+        /// hosting environments that rely on address translation and port-forwarding, such as Docker.
+        ///
+        /// Leave this setting to "0" if you don't intend to use it.
+        [<CustomOperation("public_port");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.PublicPort (state: State<Tcp.Target>, x) =
+            positiveField "public-port" x
+            |> State.addWith state Tcp.Target.Remote
+        /// Similar in spirit to "public-hostname" setting, this allows Akka.Remote users
+        /// to alias the port they're listening on. The socket will actually listen on the
+        /// "port" setting, but when connecting to other ActorSystems this node will advertise
+        /// itself as being connected to the "public-port". This is helpful when working with 
+        /// hosting environments that rely on address translation and port-forwarding, such as Docker.
+        ///
+        /// Leave this setting to "0" if you don't intend to use it.
+        member inline this.public_port value =
+            this.PublicPort(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+            
+        /// The hostname or ip to bind the remoting to,
+        /// InetAddress.getLocalHost.getHostAddress is used if empty
+        [<CustomOperation("hostname");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Hostname (state: State<Tcp.Target>, x: string) = 
+            field "hostname" x
+            |> State.addWith state Tcp.Target.Remote
+        /// The hostname or ip to bind the remoting to,
+        /// InetAddress.getLocalHost.getHostAddress is used if empty
+        member this.hostname value =
+            this.Hostname(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+            
+        /// If this value is set, this becomes the public address for the actor system on this
+        /// transport, which might be different than the physical ip address (hostname)
+        /// this is designed to make it easy to support private / public addressing schemes
+        [<CustomOperation("public_hostname");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.PublicHostname (state: State<Tcp.Target>, x: string) = 
+            field "public-hostname" x
+            |> State.addWith state Tcp.Target.Remote
+        /// If this value is set, this becomes the public address for the actor system on this
+        /// transport, which might be different than the physical ip address (hostname)
+        /// this is designed to make it easy to support private / public addressing schemes
+        member this.public_hostname value =
+            this.PublicHostname(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+        
+        /// If set to true, we will use IPV6 addresses upon DNS resolution for host names.
+        /// Otherwise, we will use IPV4.
+        [<CustomOperation("dns_use_ipv6");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.DnsUseIpv6 (state: State<Tcp.Target>, value: bool) = 
+            boolField "dns-use-ipv6" value
+            |> State.addWith state Tcp.Target.Remote
+        /// If set to true, we will use IPV6 addresses upon DNS resolution for host names.
+        /// Otherwise, we will use IPV4.
+        member this.dns_use_ipv6 value =
+            this.DnsUseIpv6(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+        
+        /// If set to true, we will enforce usage of IPV4 or IPV6 addresses upon DNS resolution for host names.
+        /// If dns-use-ipv6 = true, we will use IPV6 enforcement
+        /// Otherwise, we will use IPV4.
+        /// Warning: when ip family is enforced, any connection between IPV4 and IPV6 is impossible
+        ///
+        /// enforce-ip-family setting is used only in some special cases, when default behaviour of 
+        /// underlying sockets leads to errors. Typically this occurs when an environment doesn't support
+        /// IPV6 or dual-mode sockets.
+        /// As of 09/21/2016 there are two known cases: running under Mono and in Azure WebApp  
+        /// for them we will need enforce-ip-family = true, and for Azure dns-use-ipv6 = false
+        /// This property is always set to true if Mono runtime is detected.
+        [<CustomOperation("enforce_ip_family");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.EnforceIpFamily (state: State<Tcp.Target>, value: bool) = 
+            boolField "enforce-ip-family" value
+            |> State.addWith state Tcp.Target.Remote
+        /// If set to true, we will enforce usage of IPV4 or IPV6 addresses upon DNS resolution for host names.
+        /// If dns-use-ipv6 = true, we will use IPV6 enforcement
+        /// Otherwise, we will use IPV4.
+        /// Warning: when ip family is enforced, any connection between IPV4 and IPV6 is impossible
+        ///
+        /// enforce-ip-family setting is used only in some special cases, when default behaviour of 
+        /// underlying sockets leads to errors. Typically this occurs when an environment doesn't support
+        /// IPV6 or dual-mode sockets.
+        /// As of 09/21/2016 there are two known cases: running under Mono and in Azure WebApp  
+        /// for them we will need enforce-ip-family = true, and for Azure dns-use-ipv6 = false
+        /// This property is always set to true if Mono runtime is detected.
+        member this.enforce_ip_family value =
+            this.EnforceIpFamily(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Enables SSL support on this transport
+        [<CustomOperation("enable_ssl");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.EnableSsl (state: State<Tcp.Target>, value: bool) = 
+            boolField "enable-ssl" value
+            |> State.addWith state Tcp.Target.Remote
+        /// Enables SSL support on this transport
+        member this.enable_ssl value =
+            this.EnableSsl(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Enables backwards compatibility with Akka.Remote clients running Helios 1.*
+        [<CustomOperation("enable_backwards_compatibility");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.EnableBackwardsCompatibility (state: State<Tcp.Target>, value: bool) = 
+            boolField "enable-backwards-compatibility" value
+            |> State.addWith state Tcp.Target.Remote
+        /// Enables backwards compatibility with Akka.Remote clients running Helios 1.*
+        member this.enable_backwards_compatibility value =
+            this.EnableBackwardsCompatibility(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Sets the connectTimeoutMillis of all outbound connections,
+        /// i.e. how long a connect may take until it is timed out
+        [<CustomOperation("connection_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ConnectionTimeout (state: State<Tcp.Target>, value: 'Duration) =
+            durationField "connection-timeout" value
+            |> State.addWith state Tcp.Target.Remote
+        /// Sets the connectTimeoutMillis of all outbound connections,
+        /// i.e. how long a connect may take until it is timed out
+        member inline this.connection_timeout (value: 'Duration) =
+            this.ConnectionTimeout(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+            
+        /// If set to "<id.of.dispatcher>" then the specified dispatcher
+        /// will be used to accept inbound connections, and perform IO. If "" then
+        /// dedicated threads will be used.
+        ///
+        /// Please note that the Helios driver only uses this configuration and does
+        /// not read the "akka.remote.use-dispatcher" entry. Instead it has to be
+        /// configured manually to point to the same dispatcher if needed.
+        [<CustomOperation("use_dispatcher_for_io");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.UseDispatcherForIo (state: State<Tcp.Target>, x: string) = 
+            quotedField "use-dispatcher-for-io" x
+            |> State.addWith state Tcp.Target.Remote
+        /// If set to "<id.of.dispatcher>" then the specified dispatcher
+        /// will be used to accept inbound connections, and perform IO. If "" then
+        /// dedicated threads will be used.
+        ///
+        /// Please note that the Helios driver only uses this configuration and does
+        /// not read the "akka.remote.use-dispatcher" entry. Instead it has to be
+        /// configured manually to point to the same dispatcher if needed.
+        member this.use_dispatcher_for_io value =
+            this.UseDispatcherForIo(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+        
+        /// Sets the high water mark for the in and outbound sockets,
+        /// set to 0b for platform default
+        [<CustomOperation("write_buffer_high_water_mark");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.WriteBufferHighWaterMark (state: State<Tcp.Target>, value) =
+            byteField "write-buffer-high-water-mark" value
+            |> State.addWith state Tcp.Target.Remote
+        /// Sets the high water mark for the in and outbound sockets,
+        /// set to 0b for platform default
+        member inline this.write_buffer_high_water_mark value =
+            this.WriteBufferHighWaterMark(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Sets the low water mark for the in and outbound sockets,
+        /// set to 0b for platform default
+        [<CustomOperation("write_buffer_low_water_mark");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.WriteBufferLowhWaterMark (state: State<Tcp.Target>, value) =
+            byteField "write-buffer-low-water-mark" value
+            |> State.addWith state Tcp.Target.Remote
+        /// Sets the low water mark for the in and outbound sockets,
+        /// set to 0b for platform default
+        member inline this.write_buffer_low_water_mark value =
+            this.WriteBufferLowhWaterMark(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Sets the send buffer size of the Sockets,
+        /// set to 0b for platform default
+        [<CustomOperation("send_buffer_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.SendBufferSize (state: State<Tcp.Target>, value) =
+            byteField "send-buffer-size" value
+            |> State.addWith state Tcp.Target.Remote
+        /// Sets the send buffer size of the Sockets,
+        /// set to 0b for platform default
+        member inline this.send_buffer_size value =
+            this.SendBufferSize(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Sets the receive buffer size of the Sockets,
+        /// set to 0b for platform default
+        [<CustomOperation("receive_buffer_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ReceiveBufferSize (state: State<Tcp.Target>, value) =
+            byteField "receive-buffer-size" value
+            |> State.addWith state Tcp.Target.Remote
+        /// Sets the receive buffer size of the Sockets,
+        /// set to 0b for platform default
+        member inline this.receive_buffer_size value =
+            this.ReceiveBufferSize(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Maximum message size the transport will accept, but at least
+        /// 32000 bytes.
+        ///
+        /// Please note that UDP does not support arbitrary large datagrams,
+        /// so this setting has to be chosen carefully when using UDP.
+        /// Both send-buffer-size and receive-buffer-size settings has to
+        /// be adjusted to be able to buffer messages of maximum size.
+        [<CustomOperation("maximum_frame_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.MaximumFrameSize (state: State<Tcp.Target>, value) =
+            byteField "maximum-frame-size" value
+            |> State.addWith state Tcp.Target.Remote
+        /// Maximum message size the transport will accept, but at least
+        /// 32000 bytes.
+        ///
+        /// Please note that UDP does not support arbitrary large datagrams,
+        /// so this setting has to be chosen carefully when using UDP.
+        /// Both send-buffer-size and receive-buffer-size settings has to
+        /// be adjusted to be able to buffer messages of maximum size.
+        member inline this.maximum_frame_size value =
+            this.MaximumFrameSize(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Sets the size of the connection backlog
+        [<CustomOperation("backlog");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.Backlog (state: State<Tcp.Target>, value) =
+            positiveField "backlog" value
+            |> State.addWith state Tcp.Target.Remote
+        /// Sets the size of the connection backlog
+        member inline this.backlog value =
+            this.Backlog(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Enables the TCP_NODELAY flag, i.e. disables Nagleâ€™s algorithm
+        [<CustomOperation("tcp_nodelay");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TcpNodelay (state: State<Tcp.Target>, value: bool) = 
+            switchField "tcp-nodelay" value
+            |> State.addWith state Tcp.Target.Remote
+        /// Enables the TCP_NODELAY flag, i.e. disables Nagleâ€™s algorithm
+        member this.tcp_nodelay value =
+            this.TcpNodelay(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+        
+        /// Enables TCP Keepalive, subject to the O/S kernelâ€™s configuration
+        [<CustomOperation("tcp_keepalive");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TcpKeepalive (state: State<Tcp.Target>, value: bool) = 
+            switchField "tcp-keepalive" value
+            |> State.addWith state Tcp.Target.Remote
+        /// Enables TCP Keepalive, subject to the O/S kernelâ€™s configuration
+        member this.tcp_keepalive value =
+            this.TcpKeepalive(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+        
+        /// Enables SO_REUSEADDR, which determines when an ActorSystem can open
+        /// the specified listen port (the meaning differs between *nix and Windows)
+        ///
+        /// Valid values are "on", "off", and "off-for-windows"
+        /// due to the following Windows bug: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4476378
+        /// "off-for-windows" of course means that it's "on" for all other platforms
+        [<CustomOperation("tcp_reuse_addr");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TcpReuseAddr (state: State<Tcp.Target>, value: bool) = 
+            switchField "tcp-reuse-addr" value
+            |> State.addWith state Tcp.Target.Remote
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TcpReuseAddr (state: State<Tcp.Target>, value: Hocon.OffForWindows) = 
+            field "tcp-reuse-addr" (value.ToString())
+            |> State.addWith state Tcp.Target.Remote
+        /// Enables SO_REUSEADDR, which determines when an ActorSystem can open
+        /// the specified listen port (the meaning differs between *nix and Windows)
+        ///
+        /// Valid values are "on", "off", and "off-for-windows"
+        /// due to the following Windows bug: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4476378
+        /// "off-for-windows" of course means that it's "on" for all other platforms
+        member this.tcp_reuse_addr (value: bool) =
+            this.TcpReuseAddr(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+        /// Enables SO_REUSEADDR, which determines when an ActorSystem can open
+        /// the specified listen port (the meaning differs between *nix and Windows)
+        ///
+        /// Valid values are "on", "off", and "off-for-windows"
+        /// due to the following Windows bug: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4476378
+        /// "off-for-windows" of course means that it's "on" for all other platforms
+        member this.tcp_reuse_addr (value: Hocon.OffForWindows) =
+            this.TcpReuseAddr(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+        
+        /// configured manually to point to the same dispatcher if needed.
+        [<CustomOperation("transport_protocol");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TransportProtocol (state: State<Tcp.Target>, x: string) = 
+            field "transport-protocol" x
+            |> State.addWith state Tcp.Target.Remote
+        /// configured manually to point to the same dispatcher if needed.
+        member this.transport_protocol value =
+            this.TransportProtocol(State.create Tcp.Target.Remote [], value)
+            |> this.Run
+        
+        // Pathing
+
+        // TODO: make extensions return explicit types and have overloads at call sites for type safety
+
+        member _.direct_buffer_pool =
+            { new DirectBufferPoolBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 3 "direct-buffer-pool" state }
+        
+        member _.disabled_buffer_pool =
+            { new DisabledBufferPoolBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 3 "disabled-buffer-pool" state }
+        
+        member _.batching =
+            { new BatchingBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 4 "batching" state }
+
+        member _.client_socket_worker_pool = 
+            { new WorkerPoolBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 4 "client-socket-worker-pool" state }
+
+        member _.server_socket_worker_pool = 
+            { new WorkerPoolBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 4 "server-socket-worker-pool" state }
+
+    let tcp =
+        let path = "tcp"
+
+        { new TcpBuilder<Akka.Shared.Tcp.Field>(Akka.Shared.Tcp.Field, path) with
+            member _.Run (state: State<Tcp.Target>) : Akka.Shared.Field<Akka.Shared.Tcp.Field> =
+                fun indent ->
+                    objExpr path indent state.Fields
+                    |> Akka.Shared.Tcp.Field }

--- a/src/Akkling.Hocon/Shared.Udp.fs
+++ b/src/Akkling.Hocon/Shared.Udp.fs
@@ -1,0 +1,634 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Udp =
+    open MarkerClasses
+    open InternalHocon
+    open SharedInternal
+    open System.ComponentModel
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    module Udp =
+        [<RequireQualifiedAccess>]
+        type Target =
+            | Any
+            | IO
+            | Remote
+        
+        [<RequireQualifiedAccess>]
+        module Target =
+            let merge (target1: Target) (target2: Target) =
+                match target1, target2 with
+                | Target.Any, _
+                | _, Target.Any -> Some target1
+                | _, _ when target1 = target2 -> Some target1
+                | _ -> None
+
+        [<RequireQualifiedAccess>]
+        module State =
+            let create = State.create Target.Any
+
+    [<AbstractClass>]
+    type UdpBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string) =
+        let pathObjExpr = pathObjExpr mkField path
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        abstract Run : State<Udp.Target> -> Akka.Shared.Field<'T>
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: string) = Udp.State.create [x]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.IO.DisabledBufferPool.Field) = State.create Udp.Target.IO [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.IO.DirectBufferPool.Field) = State.create Udp.Target.IO [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Remote.Batching.Field) = State.create Udp.Target.Remote [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Remote.WorkerPool.Field) = State.create Udp.Target.Remote [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (a: unit) = Udp.State.create []
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Combine (state1: State<Udp.Target>, state2: State<Udp.Target>) : State<Udp.Target> =
+            let fields = state1.Fields @ state2.Fields
+
+            match Udp.Target.merge state1.Target state2.Target with
+            | Some target -> { Target = target; Fields = fields }
+            | None -> 
+                failwithf "Udp fields mismatch found was given:%s%A"
+                    System.Environment.NewLine fields
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Zero () = Udp.State.create []
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Delay f = f()
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member this.For (state: State<Udp.Target>, f: unit -> State<Udp.Target>) = this.Combine(state, f())
+
+        // Akka.IO
+
+        /// A buffer pool used to acquire and release byte buffers from the managed
+        /// heap. Once byte buffer is no longer needed is can be released, landing 
+        /// on the pool again, to be reused later. This way we can reduce a GC pressure
+        /// by reusing the same components instead of recycling them.
+        ///
+        /// NOTE: pooling is disabled by default, to enable use direct-buffer-pool:
+        /// set this field to "akka.io.tcp.direct-buffer-pool"
+        [<CustomOperation("buffer_pool");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.BufferPool (state: State<Udp.Target>, value: string) =
+            quotedField "buffer-pool" value
+            |> State.addWith state Udp.Target.IO
+        /// A buffer pool used to acquire and release byte buffers from the managed
+        /// heap. Once byte buffer is no longer needed is can be released, landing 
+        /// on the pool again, to be reused later. This way we can reduce a GC pressure
+        /// by reusing the same components instead of recycling them.
+        ///
+        /// NOTE: pooling is disabled by default, to enable use direct-buffer-pool:
+        /// set this field to "akka.io.tcp.direct-buffer-pool"
+        member this.buffer_pool value =
+            this.BufferPool(State.create Udp.Target.IO [], value)
+            |> this.Run
+            
+        /// The number of selectors to stripe the served channels over; each of
+        /// these will use one select loop on the selector-dispatcher.
+        [<CustomOperation("nr_of_socket_async_event_args");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.NrOfSocketAsyncEventArgs (state: State<Udp.Target>, value) =
+            positiveField "nr-of-socket-async-event-args" value
+            |> State.addWith state Udp.Target.IO
+        /// The number of selectors to stripe the served channels over; each of
+        /// these will use one select loop on the selector-dispatcher.
+        member inline this.nr_of_socket_async_event_args value =
+            this.NrOfSocketAsyncEventArgs(State.create Udp.Target.IO [], value)
+            |> this.Run
+
+        /// Maximum number of open channels supported by this UDP module Generally
+        /// UDP does not require a large number of channels, therefore it is
+        /// recommended to keep this setting low.
+        [<CustomOperation("max_channels");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.MaxChannels (state: State<Udp.Target>, value) =
+            positiveField "max-channels" value
+            |> State.addWith state Udp.Target.IO
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MaxChannels (state: State<Udp.Target>, value: Hocon.Unlimited) =
+            quotedField "max-channels" (value.ToString())
+            |> State.addWith state Udp.Target.IO
+        /// Maximum number of open channels supported by this UDP module Generally
+        /// UDP does not require a large number of channels, therefore it is
+        /// recommended to keep this setting low.
+        member inline this.max_channels value =
+            positiveField "max-channels" value
+            |> State.add (State.create Udp.Target.IO [])
+            |> this.Run
+        /// Maximum number of open channels supported by this UDP module Generally
+        /// UDP does not require a large number of channels, therefore it is
+        /// recommended to keep this setting low.
+        member this.max_channels (value: Hocon.Unlimited) =
+            this.MaxChannels(State.create Udp.Target.IO [], value)
+            |> this.Run
+            
+        /// The select loop can be used in two modes:
+        ///
+        /// - setting "infinite" will select without a timeout, hogging a thread
+        ///
+        /// - setting a positive timeout will do a bounded select call,
+        ///   enabling sharing of a single thread between multiple selectors
+        ///   (in this case you will have to use a different configuration for the
+        ///   selector-dispatcher, e.g. using "type=Dispatcher" with size 1)
+        ///
+        /// - setting it to zero means polling, i.e. calling selectNow()
+        [<CustomOperation("select_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.SelectTimeout (state: State<Udp.Target>, value: 'Duration) =
+            durationField "select-timeout" value
+            |> State.addWith state Udp.Target.IO
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SelectTimeout (state: State<Udp.Target>, value: Hocon.Infinite) =
+            field "select-timeout" (value.ToString())
+            |> State.addWith state Udp.Target.IO
+        /// The select loop can be used in two modes:
+        ///
+        /// - setting "infinite" will select without a timeout, hogging a thread
+        ///
+        /// - setting a positive timeout will do a bounded select call,
+        ///   enabling sharing of a single thread between multiple selectors
+        ///   (in this case you will have to use a different configuration for the
+        ///   selector-dispatcher, e.g. using "type=Dispatcher" with size 1)
+        ///
+        /// - setting it to zero means polling, i.e. calling selectNow()
+        member inline this.select_timeout value =
+            durationField "select-timeout" value
+            |> State.add (State.create Udp.Target.IO [])
+            |> this.Run
+        /// The select loop can be used in two modes:
+        ///
+        /// - setting "infinite" will select without a timeout, hogging a thread
+        ///
+        /// - setting a positive timeout will do a bounded select call,
+        ///   enabling sharing of a single thread between multiple selectors
+        ///   (in this case you will have to use a different configuration for the
+        ///   selector-dispatcher, e.g. using "type=Dispatcher" with size 1)
+        ///
+        /// - setting it to zero means polling, i.e. calling selectNow()
+        member this.select_timeout (value: Hocon.Infinite) =
+            this.SelectTimeout(State.create Udp.Target.IO [], value)
+            |> this.Run
+
+        /// When trying to assign a new connection to a selector and the chosen
+        /// selector is at full capacity, retry selector choosing and assignment
+        /// this many times before giving up
+        [<CustomOperation("selector_association_retries");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.SelectorAssociationRetries (state: State<Udp.Target>, value) =
+            positiveField "selector-association-retries" value
+            |> State.addWith state Udp.Target.IO
+        /// When trying to assign a new connection to a selector and the chosen
+        /// selector is at full capacity, retry selector choosing and assignment
+        /// this many times before giving up
+        member inline this.selector_association_retries value =
+            this.SelectorAssociationRetries(State.create Udp.Target.IO [], value)
+            |> this.Run
+            
+        /// The maximum number of datagrams that are read in one go,
+        /// higher numbers decrease latency, lower numbers increase fairness on
+        /// the worker-dispatcher
+        [<CustomOperation("receive_throughput");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ReceiveThroughput (state: State<Udp.Target>, value) =
+            positiveField "receive-throughput" value
+            |> State.addWith state Udp.Target.IO
+        /// The maximum number of datagrams that are read in one go,
+        /// higher numbers decrease latency, lower numbers increase fairness on
+        /// the worker-dispatcher
+        member inline this.receive_throughput value =
+            this.ReceiveThroughput(State.create Udp.Target.IO [], value)
+            |> this.Run
+
+        /// The number of bytes per direct buffer in the pool used to read or write
+        /// network data from the kernel.
+        [<CustomOperation("direct_buffer_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.DirectBufferSize (state: State<Udp.Target>, value) =
+            positiveField "direct-buffer-size" value
+            |> State.addWith state Udp.Target.IO
+        /// The number of bytes per direct buffer in the pool used to read or write
+        /// network data from the kernel.
+        member inline this.direct_buffer_size value =
+            this.DirectBufferSize(State.create Udp.Target.IO [], value)
+            |> this.Run
+
+        /// The maximal number of direct buffers kept in the direct buffer pool for
+        /// reuse.
+        [<CustomOperation("direct_buffer_pool_limit");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.DirectBufferPoolLimit (state: State<Udp.Target>, value) =
+            positiveField "direct-buffer-pool-limit" value
+            |> State.addWith state Udp.Target.IO
+        /// The maximal number of direct buffers kept in the direct buffer pool for
+        /// reuse.
+        member inline this.direct_buffer_pool_limit value =
+            this.DirectBufferPoolLimit(State.create Udp.Target.IO [], value)
+            |> this.Run
+            
+        /// The maximum number of bytes delivered by a `Received` message. Before
+        /// more data is read from the network the connection actor will try to
+        /// do other work.
+        [<CustomOperation("received_message_size_limit");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ReceivedMessageSizeLimit (state: State<Udp.Target>, value) =
+            positiveField "received-message-size-limit" value
+            |> State.addWith state Udp.Target.IO
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ReceivedMessageSizeLimit (state: State<Udp.Target>, value: Hocon.Unlimited) =
+            quotedField "received-message-size-limit" (value.ToString())
+            |> State.addWith state Udp.Target.IO
+        /// The maximum number of bytes delivered by a `Received` message. Before
+        /// more data is read from the network the connection actor will try to
+        /// do other work.
+        member inline this.received_message_size_limit value =
+            positiveField "received-message-size-limit" value
+            |> State.add (State.create Udp.Target.IO [])
+            |> this.Run
+        /// The maximum number of bytes delivered by a `Received` message. Before
+        /// more data is read from the network the connection actor will try to
+        /// do other work.
+        member this.received_message_size_limit (value: Hocon.Unlimited) =
+            this.ReceivedMessageSizeLimit(State.create Udp.Target.IO [], value)
+            |> this.Run
+
+        /// Enable fine grained logging of what goes on inside the implementation.
+        /// Be aware that this may log more than once per message sent to the actors
+        /// of the tcp implementation.
+        [<CustomOperation("trace_logging");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TraceLogging (state: State<Udp.Target>, value: bool) =
+            switchField "trace-logging" value
+            |> State.addWith state Udp.Target.IO
+        /// Enable fine grained logging of what goes on inside the implementation.
+        /// Be aware that this may log more than once per message sent to the actors
+        /// of the tcp implementation.
+        member this.trace_logging value =
+            this.TraceLogging(State.create Udp.Target.IO [], value)
+            |> this.Run
+        
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// to be used for running the select() calls in the selectors
+        [<CustomOperation("selector_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SelectorDispatcher (state: State<Udp.Target>, value: string) =
+            quotedField "selector-dispatcher" value
+            |> State.addWith state Udp.Target.IO
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// to be used for running the select() calls in the selectors
+        member this.selector_dispatcher value =
+            this.SelectorDispatcher(State.create Udp.Target.IO [], value)
+            |> this.Run
+            
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// for the read/write worker actors
+        [<CustomOperation("worker_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.WorkerDispatcher (state: State<Udp.Target>, value: string) =
+            quotedField "worker-dispatcher" value
+            |> State.addWith state Udp.Target.IO
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// for the read/write worker actors
+        member this.worker_dispatcher value =
+            this.WorkerDispatcher(State.create Udp.Target.IO [], value)
+            |> this.Run
+
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// for the selector management actors
+        [<CustomOperation("management_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ManagementDispatcher (state: State<Udp.Target>, value: string) =
+            quotedField "management-dispatcher" value
+            |> State.addWith state Udp.Target.IO
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// for the selector management actors
+        member this.management_dispatcher value =
+            this.ManagementDispatcher(State.create Udp.Target.IO [], value)
+            |> this.Run
+        
+        // Akka.Remote.DotNetty
+
+        /// The class given here must implement the akka.remote.transport.Transport
+        /// interface and offer a public constructor which takes two arguments:
+        ///
+        ///  1) akka.actor.ExtendedActorSystem
+        ///
+        ///  2) com.typesafe.config.Config
+        [<CustomOperation("transport_class");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TransportClass (state: State<Udp.Target>, x: string) = 
+            quotedField "transport-class" x
+            |> State.addWith state Udp.Target.Remote
+        /// The class given here must implement the akka.remote.transport.Transport
+        /// interface and offer a public constructor which takes two arguments:
+        ///
+        ///  1) akka.actor.ExtendedActorSystem
+        ///
+        ///  2) com.typesafe.config.Config
+        member this.transport_class value =
+            this.TransportClass(State.create Udp.Target.Remote [], value)
+            |> this.Run
+        
+        /// Transport drivers can be augmented with adapters by adding their
+        /// name to the applied-adapters list. The last adapter in the
+        /// list is the adapter immediately above the driver, while
+        /// the first one is the top of the stack below the standard
+        /// Akka protocol 
+        [<CustomOperation("applied_adapters");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AppliedAdapters (state: State<Udp.Target>, x: string list) = 
+            quotedListField "applied-adapters" x
+            |> State.addWith state Udp.Target.Remote
+        /// Transport drivers can be augmented with adapters by adding their
+        /// name to the applied-adapters list. The last adapter in the
+        /// list is the adapter immediately above the driver, while
+        /// the first one is the top of the stack below the standard
+        /// Akka protocol 
+        member this.applied_adapters value =
+            this.AppliedAdapters(State.create Udp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Byte order used for network communication. Event thou DotNetty is big-endian
+        /// by default, we need to switch it back to little endian in order to support
+        /// backward compatibility with Helios.
+        [<CustomOperation("byte_order");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.ByteOrder (state: State<Udp.Target>, x: Hocon.ByteOrder) = 
+            quotedField "byte-order" (x.Text)
+            |> State.addWith state Udp.Target.Remote
+        /// Byte order used for network communication. Event thou DotNetty is big-endian
+        /// by default, we need to switch it back to little endian in order to support
+        /// backward compatibility with Helios.
+        member this.byte_order value =
+            this.ByteOrder(State.create Udp.Target.Remote [], value)
+            |> this.Run
+        
+        /// The default remote server port clients should connect to.
+        /// Default is 2552 (AKKA), use 0 if you want a random available port
+        /// This port needs to be unique for each actor system on the same machine.
+        [<CustomOperation("port");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.Port (state: State<Udp.Target>, x) =
+            positiveField "port" x
+            |> State.addWith state Udp.Target.Remote
+        /// The default remote server port clients should connect to.
+        /// Default is 2552 (AKKA), use 0 if you want a random available port
+        /// This port needs to be unique for each actor system on the same machine.
+        member inline this.port value =
+            this.Port(State.create Udp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Similar in spirit to "public-hostname" setting, this allows Akka.Remote users
+        /// to alias the port they're listening on. The socket will actually listen on the
+        /// "port" setting, but when connecting to other ActorSystems this node will advertise
+        /// itself as being connected to the "public-port". This is helpful when working with 
+        /// hosting environments that rely on address translation and port-forwarding, such as Docker.
+        ///
+        /// Leave this setting to "0" if you don't intend to use it.
+        [<CustomOperation("public_port");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.PublicPort (state: State<Udp.Target>, x) =
+            positiveField "public-port" x
+            |> State.addWith state Udp.Target.Remote
+        /// Similar in spirit to "public-hostname" setting, this allows Akka.Remote users
+        /// to alias the port they're listening on. The socket will actually listen on the
+        /// "port" setting, but when connecting to other ActorSystems this node will advertise
+        /// itself as being connected to the "public-port". This is helpful when working with 
+        /// hosting environments that rely on address translation and port-forwarding, such as Docker.
+        ///
+        /// Leave this setting to "0" if you don't intend to use it.
+        member inline this.public_port value =
+            this.PublicPort(State.create Udp.Target.Remote [], value)
+            |> this.Run
+            
+        /// The hostname or ip to bind the remoting to,
+        /// InetAddress.getLocalHost.getHostAddress is used if empty
+        [<CustomOperation("hostname");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Hostname (state: State<Udp.Target>, x: string) = 
+            field "hostname" x
+            |> State.addWith state Udp.Target.Remote
+        /// The hostname or ip to bind the remoting to,
+        /// InetAddress.getLocalHost.getHostAddress is used if empty
+        member this.hostname value =
+            this.Hostname(State.create Udp.Target.Remote [], value)
+            |> this.Run
+            
+        /// If this value is set, this becomes the public address for the actor system on this
+        /// transport, which might be different than the physical ip address (hostname)
+        /// this is designed to make it easy to support private / public addressing schemes
+        [<CustomOperation("public_hostname");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.PublicHostname (state: State<Udp.Target>, x: string) = 
+            field "public-hostname" x
+            |> State.addWith state Udp.Target.Remote
+        /// If this value is set, this becomes the public address for the actor system on this
+        /// transport, which might be different than the physical ip address (hostname)
+        /// this is designed to make it easy to support private / public addressing schemes
+        member this.public_hostname value =
+            this.PublicHostname(State.create Udp.Target.Remote [], value)
+            |> this.Run
+        
+        /// If set to true, we will use IPV6 addresses upon DNS resolution for host names.
+        /// Otherwise, we will use IPV4.
+        [<CustomOperation("dns_use_ipv6");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.DnsUseIpv6 (state: State<Udp.Target>, value: bool) = 
+            boolField "dns-use-ipv6" value
+            |> State.addWith state Udp.Target.Remote
+        /// If set to true, we will use IPV6 addresses upon DNS resolution for host names.
+        /// Otherwise, we will use IPV4.
+        member this.dns_use_ipv6 value =
+            this.DnsUseIpv6(State.create Udp.Target.Remote [], value)
+            |> this.Run
+        
+        /// If set to true, we will enforce usage of IPV4 or IPV6 addresses upon DNS resolution for host names.
+        /// If dns-use-ipv6 = true, we will use IPV6 enforcement
+        /// Otherwise, we will use IPV4.
+        /// Warning: when ip family is enforced, any connection between IPV4 and IPV6 is impossible
+        ///
+        /// enforce-ip-family setting is used only in some special cases, when default behaviour of 
+        /// underlying sockets leads to errors. Typically this occurs when an environment doesn't support
+        /// IPV6 or dual-mode sockets.
+        /// As of 09/21/2016 there are two known cases: running under Mono and in Azure WebApp  
+        /// for them we will need enforce-ip-family = true, and for Azure dns-use-ipv6 = false
+        /// This property is always set to true if Mono runtime is detected.
+        [<CustomOperation("enforce_ip_family");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.EnforceIpFamily (state: State<Udp.Target>, value: bool) = 
+            boolField "enforce-ip-family" value
+            |> State.addWith state Udp.Target.Remote
+        /// If set to true, we will enforce usage of IPV4 or IPV6 addresses upon DNS resolution for host names.
+        /// If dns-use-ipv6 = true, we will use IPV6 enforcement
+        /// Otherwise, we will use IPV4.
+        /// Warning: when ip family is enforced, any connection between IPV4 and IPV6 is impossible
+        ///
+        /// enforce-ip-family setting is used only in some special cases, when default behaviour of 
+        /// underlying sockets leads to errors. Typically this occurs when an environment doesn't support
+        /// IPV6 or dual-mode sockets.
+        /// As of 09/21/2016 there are two known cases: running under Mono and in Azure WebApp  
+        /// for them we will need enforce-ip-family = true, and for Azure dns-use-ipv6 = false
+        /// This property is always set to true if Mono runtime is detected.
+        member this.enforce_ip_family value =
+            this.EnforceIpFamily(State.create Udp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Enables SSL support on this transport
+        [<CustomOperation("enable_ssl");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.EnableSsl (state: State<Udp.Target>, value: bool) = 
+            boolField "enable-ssl" value
+            |> State.addWith state Udp.Target.Remote
+        /// Enables SSL support on this transport
+        member this.enable_ssl value =
+            this.EnableSsl(State.create Udp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Enables backwards compatibility with Akka.Remote clients running Helios 1.*
+        [<CustomOperation("enable_backwards_compatibility");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.EnableBackwardsCompatibility (state: State<Udp.Target>, value: bool) = 
+            boolField "enable-backwards-compatibility" value
+            |> State.addWith state Udp.Target.Remote
+        /// Enables backwards compatibility with Akka.Remote clients running Helios 1.*
+        member this.enable_backwards_compatibility value =
+            this.EnableBackwardsCompatibility(State.create Udp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Sets the connectTimeoutMillis of all outbound connections,
+        /// i.e. how long a connect may take until it is timed out
+        [<CustomOperation("connection_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ConnectionTimeout (state: State<Udp.Target>, value: 'Duration) =
+            durationField "connection-timeout" value
+            |> State.addWith state Udp.Target.Remote
+        /// Sets the connectTimeoutMillis of all outbound connections,
+        /// i.e. how long a connect may take until it is timed out
+        member inline this.connection_timeout (value: 'Duration) =
+            this.ConnectionTimeout(State.create Udp.Target.Remote [], value)
+            |> this.Run
+            
+        /// If set to "<id.of.dispatcher>" then the specified dispatcher
+        /// will be used to accept inbound connections, and perform IO. If "" then
+        /// dedicated threads will be used.
+        ///
+        /// Please note that the Helios driver only uses this configuration and does
+        /// not read the "akka.remote.use-dispatcher" entry. Instead it has to be
+        /// configured manually to point to the same dispatcher if needed.
+        [<CustomOperation("use_dispatcher_for_io");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.UseDispatcherForIo (state: State<Udp.Target>, x: string) = 
+            quotedField "use-dispatcher-for-io" x
+            |> State.addWith state Udp.Target.Remote
+        /// If set to "<id.of.dispatcher>" then the specified dispatcher
+        /// will be used to accept inbound connections, and perform IO. If "" then
+        /// dedicated threads will be used.
+        ///
+        /// Please note that the Helios driver only uses this configuration and does
+        /// not read the "akka.remote.use-dispatcher" entry. Instead it has to be
+        /// configured manually to point to the same dispatcher if needed.
+        member this.use_dispatcher_for_io value =
+            this.UseDispatcherForIo(State.create Udp.Target.Remote [], value)
+            |> this.Run
+        
+        /// Sets the high water mark for the in and outbound sockets,
+        /// set to 0b for platform default
+        [<CustomOperation("write_buffer_high_water_mark");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.WriteBufferHighWaterMark (state: State<Udp.Target>, value) =
+            byteField "write-buffer-high-water-mark" value
+            |> State.addWith state Udp.Target.Remote
+        /// Sets the high water mark for the in and outbound sockets,
+        /// set to 0b for platform default
+        member inline this.write_buffer_high_water_mark value =
+            this.WriteBufferHighWaterMark(State.create Udp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Sets the low water mark for the in and outbound sockets,
+        /// set to 0b for platform default
+        [<CustomOperation("write_buffer_low_water_mark");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.WriteBufferLowhWaterMark (state: State<Udp.Target>, value) =
+            byteField "write-buffer-low-water-mark" value
+            |> State.addWith state Udp.Target.Remote
+        /// Sets the low water mark for the in and outbound sockets,
+        /// set to 0b for platform default
+        member inline this.write_buffer_low_water_mark value =
+            this.WriteBufferLowhWaterMark(State.create Udp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Sets the send buffer size of the Sockets,
+        /// set to 0b for platform default
+        [<CustomOperation("send_buffer_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.SendBufferSize (state: State<Udp.Target>, value) =
+            byteField "send-buffer-size" value
+            |> State.addWith state Udp.Target.Remote
+        /// Sets the send buffer size of the Sockets,
+        /// set to 0b for platform default
+        member inline this.send_buffer_size value =
+            this.SendBufferSize(State.create Udp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Sets the receive buffer size of the Sockets,
+        /// set to 0b for platform default
+        [<CustomOperation("receive_buffer_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.ReceiveBufferSize (state: State<Udp.Target>, value) =
+            byteField "receive-buffer-size" value
+            |> State.addWith state Udp.Target.Remote
+        /// Sets the receive buffer size of the Sockets,
+        /// set to 0b for platform default
+        member inline this.receive_buffer_size value =
+            this.ReceiveBufferSize(State.create Udp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Maximum message size the transport will accept, but at least
+        /// 32000 bytes.
+        ///
+        /// Please note that UDP does not support arbitrary large datagrams,
+        /// so this setting has to be chosen carefully when using UDP.
+        /// Both send-buffer-size and receive-buffer-size settings has to
+        /// be adjusted to be able to buffer messages of maximum size.
+        [<CustomOperation("maximum_frame_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.MaximumFrameSize (state: State<Udp.Target>, value) =
+            byteField "maximum-frame-size" value
+            |> State.addWith state Udp.Target.Remote
+        /// Maximum message size the transport will accept, but at least
+        /// 32000 bytes.
+        ///
+        /// Please note that UDP does not support arbitrary large datagrams,
+        /// so this setting has to be chosen carefully when using UDP.
+        /// Both send-buffer-size and receive-buffer-size settings has to
+        /// be adjusted to be able to buffer messages of maximum size.
+        member inline this.maximum_frame_size value =
+            this.MaximumFrameSize(State.create Udp.Target.Remote [], value)
+            |> this.Run
+            
+        /// Sets the size of the connection backlog
+        [<CustomOperation("backlog");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.Backlog (state: State<Udp.Target>, value) =
+            positiveField "backlog" value
+            |> State.addWith state Udp.Target.Remote
+        /// Sets the size of the connection backlog
+        member inline this.backlog value =
+            this.Backlog(State.create Udp.Target.Remote [], value)
+            |> this.Run
+        
+        /// configured manually to point to the same dispatcher if needed.
+        [<CustomOperation("transport_protocol");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.TransportProtocol (state: State<Udp.Target>, x: string) = 
+            field "transport-protocol" x
+            |> State.addWith state Udp.Target.Remote
+        /// configured manually to point to the same dispatcher if needed.
+        member this.transport_protocol value =
+            this.TransportProtocol(State.create Udp.Target.Remote [], value)
+            |> this.Run
+        
+        // Pathing
+
+        member _.direct_buffer_pool =
+            { new DirectBufferPoolBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 0 "direct-buffer-pool" state }
+        
+        member _.client_socket_worker_pool = 
+            { new WorkerPoolBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 0 "client-socket-worker-pool" state }
+
+        member _.server_socket_worker_pool = 
+            { new WorkerPoolBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr 0 "server-socket-worker-pool" state }
+
+    let udp =
+        let path = "udp"
+
+        { new UdpBuilder<Akka.Shared.Udp.Field>(Akka.Shared.Udp.Field, path) with
+            member _.Run (state: State<Udp.Target>) : Akka.Shared.Field<Akka.Shared.Udp.Field> =
+                fun indent ->
+                    objExpr path indent state.Fields
+                    |> Akka.Shared.Udp.Field }
+
+    let udp_connected =
+        let path = "udp-connected"
+
+        { new UdpBuilder<Akka.Shared.Udp.Field>(Akka.Shared.Udp.Field, path) with
+            member _.Run (state: State<Udp.Target>) : Akka.Shared.Field<Akka.Shared.Udp.Field> =
+                fun indent ->
+                    objExpr path indent state.Fields
+                    |> Akka.Shared.Udp.Field }

--- a/src/Akkling.Hocon/Shared.fs
+++ b/src/Akkling.Hocon/Shared.fs
@@ -1,0 +1,20 @@
+﻿namespace Akkling.Hocon
+
+open System.ComponentModel
+
+[<EditorBrowsable(EditorBrowsableState.Never)>]
+module SharedInternal =
+    type State<'T> =
+        { Target: 'T
+          Fields: string list }
+
+    [<RequireQualifiedAccess>]
+    module State =
+        let create (defaultTarget: 'T) (fields: string list) =
+            { Target = defaultTarget; Fields = fields }
+
+        let add (state: State<'T>) (field: string) =
+            { state with Fields = field::state.Fields }
+
+        let addWith (state: State<'T>) (target: 'T) (field: string) =
+            { Target = target; Fields = field::state.Fields }

--- a/src/Akkling.Hocon/Streams.fs
+++ b/src/Akkling.Hocon/Streams.fs
@@ -1,0 +1,348 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Streams =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+    
+    [<AbstractClass>]
+    type SubscriptionTimeoutBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        /// When the subscription timeout is reached one of the following strategies on
+        /// the "stale" publisher:
+        /// cancel - cancel it (via `onError` or subscribing to the publisher and
+        ///          `cancel()`ing the subscription right away
+        /// warn   - log a warning statement about the stale element (then drop the
+        ///          reference to it)
+        /// noop   - do nothing (not recommended)		
+        /// Note: If you change this value also change the fallback value in StreamSubscriptionTimeoutSettings
+        [<CustomOperation("mode");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Mode (state: string list, x: Hocon.SubscriptionTimeout.Mode) =
+            field "mode" x.Text::state
+        /// When the subscription timeout is reached one of the following strategies on
+        /// the "stale" publisher:
+        /// cancel - cancel it (via `onError` or subscribing to the publisher and
+        ///          `cancel()`ing the subscription right away
+        /// warn   - log a warning statement about the stale element (then drop the
+        ///          reference to it)
+        /// noop   - do nothing (not recommended)		
+        /// Note: If you change this value also change the fallback value in StreamSubscriptionTimeoutSettings
+        member this.mode value =
+            this.Mode([], value)
+            |> this.Run
+        
+        /// Time after which a subscriber / publisher is considered stale and eligible
+        /// for cancelation (see `akka.stream.subscription-timeout.mode`)		
+        /// Note: If you change this value also change the fallback value in StreamSubscriptionTimeoutSettings
+        [<CustomOperation("timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.Timeout (state: string list, value: 'Duration) =
+            durationField "timeout" value::state
+        /// Time after which a subscriber / publisher is considered stale and eligible
+        /// for cancelation (see `akka.stream.subscription-timeout.mode`)		
+        /// Note: If you change this value also change the fallback value in StreamSubscriptionTimeoutSettings
+        member inline this.timeout (value: 'Duration) =
+            this.Timeout([], value)
+            |> this.Run
+
+    let subscription_timeout =
+        { new SubscriptionTimeoutBuilder<Akka.Streams.Materializer.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "subscription-timeout" 4 state
+                |> Akka.Streams.Materializer.Field }
+    
+    [<AbstractClass>]
+    type StreamRefBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        /// Buffer of a SinkRef that is used to batch Request elements from the other side of the stream ref
+        ///
+        /// The buffer will be attempted to be filled eagerly even while the local stage did not request elements,
+        /// because the delay of requesting over network boundaries is much higher.
+        [<CustomOperation("buffer_capacity");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.BufferCapacity (state: string list, value: int) =
+            positiveField "buffer-capacity" value::state
+        /// Buffer of a SinkRef that is used to batch Request elements from the other side of the stream ref
+        ///
+        /// The buffer will be attempted to be filled eagerly even while the local stage did not request elements,
+        /// because the delay of requesting over network boundaries is much higher.
+        member this.buffer_capacity value =
+            this.BufferCapacity([], value)
+            |> this.Run
+        
+        /// Demand is signalled by sending a cumulative demand message ("requesting messages until the n-th sequence number)
+        /// Using a cumulative demand model allows us to re-deliver the demand message in case of message loss (which should
+        /// be very rare in any case, yet possible -- mostly under connection break-down and re-establishment).
+        ///
+        /// The semantics of handling and updating the demand however are in-line with what Reactive Streams dictates.
+        ///
+        /// In normal operation, demand is signalled in response to arriving elements, however if no new elements arrive
+        /// within `demand-redelivery-interval` a re-delivery of the demand will be triggered, assuming that it may have gotten lost.
+        [<CustomOperation("demand_redelivery_interval");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.DemandRedeliveryInterval (state: string list, value: 'Duration) =
+            durationField "demand-redelivery-interval" value::state
+        /// Demand is signalled by sending a cumulative demand message ("requesting messages until the n-th sequence number)
+        /// Using a cumulative demand model allows us to re-deliver the demand message in case of message loss (which should
+        /// be very rare in any case, yet possible -- mostly under connection break-down and re-establishment).
+        ///
+        /// The semantics of handling and updating the demand however are in-line with what Reactive Streams dictates.
+        ///
+        /// In normal operation, demand is signalled in response to arriving elements, however if no new elements arrive
+        /// within `demand-redelivery-interval` a re-delivery of the demand will be triggered, assuming that it may have gotten lost.
+        member inline this.demand_redelivery_interval (value: 'Duration) =
+            this.DemandRedeliveryInterval([], value)
+            |> this.Run
+            
+        /// Subscription timeout, during which the "remote side" MUST subscribe (materialize) the handed out stream ref.
+        /// This timeout does not have to be very low in normal situations, since the remote side may also need to
+        /// prepare things before it is ready to materialize the reference. However the timeout is needed to avoid leaking
+        /// in-active streams which are never subscribed to.
+        [<CustomOperation("subscription_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.SubscriptionTimeout (state: string list, value: 'Duration) =
+            durationField "subscription-timeout" value::state
+        /// Subscription timeout, during which the "remote side" MUST subscribe (materialize) the handed out stream ref.
+        /// This timeout does not have to be very low in normal situations, since the remote side may also need to
+        /// prepare things before it is ready to materialize the reference. However the timeout is needed to avoid leaking
+        /// in-active streams which are never subscribed to.
+        member inline this.subscription_timeout (value: 'Duration) =
+            this.SubscriptionTimeout([], value)
+            |> this.Run
+            
+        /// In order to guard the receiving end of a stream ref from never terminating (since awaiting a Completion or Failed
+        /// message) after / before a Terminated is seen, a special timeout is applied once Terminated is received by it.
+        /// This allows us to terminate stream refs that have been targeted to other nodes which are Downed, and as such the
+        /// other side of the stream ref would never send the "final" terminal message.
+        ///
+        /// The timeout specifically means the time between the Terminated signal being received and when the local SourceRef
+        /// determines to fail itself, assuming there was message loss or a complete partition of the completion signal.
+        [<CustomOperation("final_termination_signal_deadline");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.FinalTerminationSignalDeadline (state: string list, value: 'Duration) =
+            durationField "final-termination-signal-deadline" value::state
+        /// In order to guard the receiving end of a stream ref from never terminating (since awaiting a Completion or Failed
+        /// message) after / before a Terminated is seen, a special timeout is applied once Terminated is received by it.
+        /// This allows us to terminate stream refs that have been targeted to other nodes which are Downed, and as such the
+        /// other side of the stream ref would never send the "final" terminal message.
+        ///
+        /// The timeout specifically means the time between the Terminated signal being received and when the local SourceRef
+        /// determines to fail itself, assuming there was message loss or a complete partition of the completion signal.
+        member inline this.final_termination_signal_deadline (value: 'Duration) =
+            this.FinalTerminationSignalDeadline([], value)
+            |> this.Run
+
+    let stream_ref =
+        { new StreamRefBuilder<Akka.Streams.Materializer.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "stream-ref" 4 state
+                |> Akka.Streams.Materializer.Field }
+    
+    [<AbstractClass>]
+    type MaterializerBuilder<'T when 'T :> IField> (mkField: string -> 'T, path: string, indent: int) =
+        inherit BaseBuilder<'T>()
+        
+        let pathObjExpr = pathObjExpr mkField path indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Shared.Field<Akka.Shared.Debug.Field>) = [(x 4).ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Streams.Materializer.Field) = [x.ToString()]
+        
+        /// Initial size of buffers used in stream elements
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        [<CustomOperation("initial_input_buffer_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.InitialInputBufferSize (state: string list, value: int) =
+            positiveField "initial-input-buffer-size" value::state
+        /// Initial size of buffers used in stream elements
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        member this.initial_input_buffer_size value =
+            this.InitialInputBufferSize([], value)
+            |> this.Run
+        
+        /// Maximum size of buffers used in stream elements
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        [<CustomOperation("max_input_buffer_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MaxInputBufferSize (state: string list, value: int) =
+            positiveField "max-input-buffer-size" value::state
+        /// Maximum size of buffers used in stream elements
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        member this.max_input_buffer_size value =
+            this.MaxInputBufferSize([], value)
+            |> this.Run
+        
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// to be used by FlowMaterialiser when creating Actors.
+        /// When this value is left empty, the default-dispatcher will be used.
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        [<CustomOperation("dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Dispatcher (state: string list, x: string) =
+            quotedField "dispatcher" x::state
+        /// Fully qualified config path which holds the dispatcher configuration
+        /// to be used by FlowMaterialiser when creating Actors.
+        /// When this value is left empty, the default-dispatcher will be used.
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        member this.dispatcher value =
+            this.Dispatcher([], value)
+            |> this.Run
+        
+        /// Storage location of snapshot files.
+        [<CustomOperation("blocking_io_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.BlockingIoDispatcher (state: string list, x: string) =
+            quotedField "blocking-io-dispatcher" x::state
+        /// Storage location of snapshot files.
+        member this.blocking_io_dispatcher value =
+            this.BlockingIoDispatcher([], value)
+            |> this.Run
+        
+        /// Enable additional troubleshooting logging at DEBUG log level
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        [<CustomOperation("debug_logging");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.DebugLogging (state: string list, value: bool) = 
+            switchField "debug-logging" value::state
+        /// Enable additional troubleshooting logging at DEBUG log level
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        member this.debug_logging value =
+            this.DebugLogging([], value)
+            |> this.Run
+    
+        /// Maximum number of elements emitted in batch if downstream signals large demand
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        [<CustomOperation("output_burst_limit");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.OutputBurstLimit (state: string list, value: int) =
+            positiveField "output-burst-limit" value::state
+        /// Maximum number of elements emitted in batch if downstream signals large demand
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        member this.output_burst_limit value =
+            this.OutputBurstLimit([], value)
+            |> this.Run
+        
+        /// Enable automatic fusing of all graphs that are run. For short-lived streams
+        /// this may cause an initial runtime overhead, but most of the time fusing is
+        /// desirable since it reduces the number of Actors that are created.
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        [<CustomOperation("auto_fusing");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.AutoFusing (state: string list, value: bool) = 
+            switchField "auto-fusing" value::state
+        /// Enable automatic fusing of all graphs that are run. For short-lived streams
+        /// this may cause an initial runtime overhead, but most of the time fusing is
+        /// desirable since it reduces the number of Actors that are created.
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        member this.auto_fusing value =
+            this.AutoFusing([], value)
+            |> this.Run
+    
+        /// Those stream elements which have explicit buffers (like mapAsync, mapAsyncUnordered,
+        /// buffer, flatMapMerge, Source.actorRef, Source.queue, etc.) will preallocate a fixed
+        /// buffer upon stream materialization if the requested buffer size is less than this
+        /// configuration parameter. The default is very high because failing early is better
+        /// than failing under load.
+        ///
+        /// Buffers sized larger than this will dynamically grow/shrink and consume more memory
+        /// per element than the fixed size buffers.
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        [<CustomOperation("max_fixed_buffer_size");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.MaxFixedBufferSize (state: string list, value: int) =
+            positiveField "max-fixed-buffer-size" value::state
+        /// Those stream elements which have explicit buffers (like mapAsync, mapAsyncUnordered,
+        /// buffer, flatMapMerge, Source.actorRef, Source.queue, etc.) will preallocate a fixed
+        /// buffer upon stream materialization if the requested buffer size is less than this
+        /// configuration parameter. The default is very high because failing early is better
+        /// than failing under load.
+        ///
+        /// Buffers sized larger than this will dynamically grow/shrink and consume more memory
+        /// per element than the fixed size buffers.
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        member this.max_fixed_buffer_size value =
+            this.MaxFixedBufferSize([], value)
+            |> this.Run
+        
+        /// Maximum number of sync messages that actor can process for stream to substream communication.
+        /// Parameter allows to interrupt synchronous processing to get upsteam/downstream messages.
+        /// Allows to accelerate message processing that happening withing same actor but keep system responsive.
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        [<CustomOperation("sync_processing_limit");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.SyncProcessingLimit (state: string list, value: int) =
+            positiveField "sync-processing-limit" value::state
+        /// Maximum number of sync messages that actor can process for stream to substream communication.
+        /// Parameter allows to interrupt synchronous processing to get upsteam/downstream messages.
+        /// Allows to accelerate message processing that happening withing same actor but keep system responsive.
+        ///
+        /// Note: If you change this value also change the fallback value in ActorMaterializerSettings
+        member this.sync_processing_limit value =
+            this.SyncProcessingLimit([], value)
+            |> this.Run
+        
+        // Pathing
+        
+        member _.stream_ref =
+            { new StreamRefBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "stream-ref" state }
+        
+        member _.subscription_timeout =
+            { new SubscriptionTimeoutBuilder<'T>() with
+                member _.Run (state: string list) = pathObjExpr "subscription-timeout" state }
+        
+    let materializer =
+        let path = "materializer"
+        let indent = 3
+
+        { new MaterializerBuilder<Akka.Streams.Field>(Akka.Streams.Field, path, indent) with
+            member _.Run (state: string list) = 
+                objExpr path indent state
+                |> Akka.Streams.Field }
+    
+    [<AbstractClass>]
+    type StreamBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        let indent = 2
+        let pathObjExpr = pathObjExpr Akka.Field "actor" indent
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Streams.Field) = [x.ToString()]
+        
+        /// Deprecated, left here to not break Akka HTTP which refers to it
+        [<CustomOperation("blocking_io_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.BlockingIoDispatcher (state: string list, value: string) =
+            quotedField "blocking-io-dispatcher" value::state
+        /// Deprecated, left here to not break Akka HTTP which refers to it
+        member this.blocking_io_dispatcher value =
+            this.BlockingIoDispatcher([], value)
+            |> this.Run
+            
+        /// Deprecated, will not be used unless user code refer to it, use 'akka.stream.materializer.blocking-io-dispatcher'
+        /// instead, or if from code, prefer the 'ActorAttributes.IODispatcher' attribute
+        [<CustomOperation("default_blocking_io_dispatcher");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.DefaultBlockingIoDispatcher (state: string list, value: string) =
+            quotedField "default-blocking-io-dispatcher" value::state
+        /// Deprecated, will not be used unless user code refer to it, use 'akka.stream.materializer.blocking-io-dispatcher'
+        /// instead, or if from code, prefer the 'ActorAttributes.IODispatcher' attribute
+        member this.default_blocking_io_dispatcher value =
+            this.DefaultBlockingIoDispatcher([], value)
+            |> this.Run
+        
+        // Pathing
+        
+        member _.materializer =
+            { new MaterializerBuilder<Akka.Field>(Akka.Field, "stream.materializer", indent) with
+                member _.Run (state: string list) = pathObjExpr "materializer" state }
+        
+    let stream =
+        { new StreamBuilder<Akka.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "stream" 2 state
+                |> Akka.Field }

--- a/src/Akkling.Hocon/Test.fs
+++ b/src/Akkling.Hocon/Test.fs
@@ -1,0 +1,78 @@
+﻿namespace Akkling.Hocon
+
+[<AutoOpen>]
+module Test =
+    open MarkerClasses
+    open InternalHocon
+    open System.ComponentModel
+
+    let test_actor =
+        { new ActorBuilder<Akka.Test.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "test-actor" 3 state
+                |> Akka.Test.Field }
+    
+    [<AbstractClass>]
+    type TestBuilder<'T when 'T :> IField> () =
+        inherit BaseBuilder<'T>()
+        
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Test.Field) = [x.ToString()]
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Yield (x: Akka.Actor.Dispatcher.Field) = [x.ToString()]
+        
+        /// Factor by which to scale timeouts during tests, e.g. to account for shared
+        /// build system load
+        [<CustomOperation("timefactor");EditorBrowsable(EditorBrowsableState.Never)>]
+        member _.Timefactor (state: string list, value: float) =
+            positiveFieldf "timefactor" value::state
+        /// Factor by which to scale timeouts during tests, e.g. to account for shared
+        /// build system load
+        member this.timefactor value =
+            this.Timefactor([], value)
+            |> this.Run
+            
+        /// Duration of EventFilter.intercept waits after the block is finished until
+        /// all required messages are received
+        [<CustomOperation("filter_leeway");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.FilterLeeway (state: string list, value: 'Duration) =
+            durationField "filter-leeway" value::state
+        /// Duration of EventFilter.intercept waits after the block is finished until
+        /// all required messages are received
+        member inline this.filter_leeway (value: 'Duration) =
+            this.FilterLeeway([], value)
+            |> this.Run
+        
+        /// The timeout that is added as an implicit by DefaultTimeout trait 
+        /// This is used for Ask-pattern
+        [<CustomOperation("single_expect_default");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.SingleExpectDefault (state: string list, value: 'Duration) =
+            durationField "single-expect-default" value::state
+        /// The timeout that is added as an implicit by DefaultTimeout trait 
+        /// This is used for Ask-pattern
+        member inline this.single_expect_default (value: 'Duration) =
+            this.SingleExpectDefault([], value)
+            |> this.Run
+        
+        /// determines to fail itself, assuming there was message loss or a complete partition of the completion signal.
+        [<CustomOperation("default_timeout");EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline _.DefaultTimeout (state: string list, value: 'Duration) =
+            durationField "default-timeout" value::state
+        /// determines to fail itself, assuming there was message loss or a complete partition of the completion signal.
+        member inline this.default_timeout (value: 'Duration) =
+            this.DefaultTimeout([], value)
+            |> this.Run
+
+        // Pathing
+
+        member _.test_actor =
+            { new ActorBuilder<Akka.Field>() with
+                member _.Run (state: string list) = 
+                    objExpr "test.test-actor" 2 state
+                    |> Akka.Field }
+
+    let test =
+        { new TestBuilder<Akka.Field>() with
+            member _.Run (state: string list) = 
+                objExpr "test" 2 state
+                |> Akka.Field }

--- a/src/Akkling.Hocon/Types.fs
+++ b/src/Akkling.Hocon/Types.fs
@@ -1,0 +1,614 @@
+﻿namespace Akkling.Hocon
+
+open System.ComponentModel
+
+[<AutoOpen>]
+module Units =
+    [<AutoOpen>]
+    module Duration =
+        /// Nanoseconds
+        type [<Measure>] ns
+
+        /// Microseconds
+        type [<Measure>] us
+
+        /// Miliseconds
+        type [<Measure>] ms
+
+        /// Seconds
+        type [<Measure>] s
+
+        /// Minutes
+        type [<Measure>] m
+
+        /// Hours
+        type [<Measure>] h
+
+        /// Days
+        type [<Measure>] d
+
+    [<AutoOpen>]
+    module Bytes =
+        /// Bytes
+        type [<Measure>] B
+
+        /// Kilobytes
+        type [<Measure>] kB
+        /// Kibibytes
+        type [<Measure>] KiB
+
+        /// Megabytes
+        type [<Measure>] MB
+        /// Mebibytes
+        type [<Measure>] MiB
+
+        /// Gigabytes
+        type [<Measure>] GB
+        /// Gibibytes
+        type [<Measure>] GiB
+
+        /// Terabytes
+        type [<Measure>] TB
+        /// Tebibytes
+        type [<Measure>] TiB
+
+        /// Petabytes
+        type [<Measure>] PB
+        /// Pebibytes
+        type [<Measure>] PiB
+
+        /// Exabytes
+        type [<Measure>] EB
+        /// Exbibytes
+        type [<Measure>] EiB
+
+        /// Zettabytes
+        type [<Measure>] ZB
+        /// Zebibytes
+        type [<Measure>] ZiB
+
+        /// Yottabytes
+        type [<Measure>] YB
+        /// Yobibytes
+        type [<Measure>] YiB
+
+[<AutoOpen>]
+module Types =
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    module MarkerClasses =
+        type IField = interface end
+
+        module Akka =
+            type Field internal (s: string) = 
+                interface IField
+
+                override _.ToString () = s
+
+            module Actor =
+                type Field internal (s: string) = 
+                    interface IField
+
+                    override _.ToString () = s
+                
+                module CurrentContextExecutor =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+                      
+                module DefaultExecutor =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+                    
+                module DedicatedThreadPool =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+                module Deployment =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+                   
+                module DeploymentDefault =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+                
+                module Dispatcher =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+                module ForkJoinExecutor =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+                
+                module Mailbox =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+                        
+                module Router =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+            
+                module RouterTypeMapping =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+                
+                module ThreadPoolExecutor =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+                      
+                module Typed =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+            module Cluster =
+                type Field internal (s: string) = 
+                    interface IField
+
+                    override _.ToString () = s
+                
+                module Client =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+                module Metrics =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+                module SplitBrainResolver =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+                
+                module Strategy =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+                module Supervisor =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+            module CoordinatedShutdown =
+                type Field internal (s: string) = 
+                    interface IField
+
+                    override _.ToString () = s
+                
+                module Phases =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+            module IO =
+                type Field internal (s: string) = 
+                    interface IField
+
+                    override _.ToString () = s
+                
+                module DisabledBufferPool =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+                module DirectBufferPool =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s              
+
+                module Dns =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+                    
+                module INetAddress =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+            
+            module Persistence =
+                type Field internal (s: string) = 
+                    interface IField
+
+                    override _.ToString () = s
+
+                module CircuitBreaker =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+                module Plugin =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+                module SnapshotStore =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+                
+                module ReplayFilter =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+            module Remote =
+                type Field internal (s: string) = 
+                    interface IField
+
+                    override _.ToString () = s
+
+                module Batching =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+                    
+                module Certificate =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+                module DotNetty =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+                                    
+                module WorkerPool =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+            module Scheduler =
+                type Field internal (s: string) = 
+                    interface IField
+
+                    override _.ToString () = s
+
+            module Shared =
+                type Field<'T> = int -> 'T
+
+                module Cluster =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+                module Debug =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+                module Tcp =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+                    
+                module Udp =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+            module Streams =
+                type Field internal (s: string) = 
+                    interface IField
+
+                    override _.ToString () = s
+
+                module Materializer =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+            module Test =
+                type Field internal (s: string) = 
+                    interface IField
+
+                    override _.ToString () = s
+
+                module TestActor =
+                    type Field internal (s: string) = 
+                        interface IField
+
+                        override _.ToString () = s
+
+module Hocon =
+    [<NoComparison;NoEquality>]
+    type Infinite internal () = override _.ToString () = "infinite"
+
+    let infinite = Infinite()
+
+    [<NoComparison;NoEquality>]
+    type Unlimited internal () = override _.ToString () = "unlimited"
+
+    let unlimited = Unlimited()
+    
+    [<NoComparison;NoEquality>]
+    type OffForWindows internal () = override _.ToString () = "off-for-windows"
+
+    let offForWindows = OffForWindows()
+    
+    type Bytes =
+        static member bytes (i: int) = i * 1<B>
+
+        static member kilobytes (i: int) = i * 1<kB>
+        static member kibibytes (i: int) = i * 1<KiB>
+
+        static member megabytes (i: int) = i * 1<MB>
+        static member mebibytes (i: int) = i * 1<MiB>
+        
+        static member gigabytes (i: int) = i * 1<GB>
+        static member gibibytes (i: int) = i * 1<GiB>
+        
+        static member terabytes (i: int) = i * 1<TB>
+        static member tebibytes (i: int) = i * 1<TiB>
+        
+        static member petabytes (i: int) = i * 1<PB>
+        static member pebibytes (i: int) = i * 1<PiB>
+        
+        static member exabytes (i: int) = i * 1<EB>
+        static member exbibytes (i: int) = i * 1<EiB>
+        
+        static member zettabytes (i: int) = i * 1<ZB>
+        static member zebibytes (i: int) = i * 1<ZiB>
+        
+        static member yottabytes (i: int) = i * 1<YB>
+        static member yobibytes (i: int) = i * 1<YiB>
+
+    [<RequireQualifiedAccess>]
+    type ByteOrder =
+        | BigEndian
+        | LittleEndian
+
+        member internal this.Text =
+            match this with
+            | BigEndian -> "big-endian"
+            | LittleEndian -> "little-endian"
+
+    [<RequireQualifiedAccess>]
+    type Dispatcher =
+        | Dispatcher
+        | ForkJoinDispatcher
+        | PinnedDispatcher
+        | SynchronizedDispatcher
+        | TaskDispatcher
+        | ThreadPoolDispatcher
+
+        member internal this.Text =
+            match this with
+            | Dispatcher -> "Dispatcher"
+            | ForkJoinDispatcher -> "ForkJoinDispatcher"
+            | PinnedDispatcher -> "PinnedDispatcher"
+            | SynchronizedDispatcher -> "SynchronizedDispatcher"
+            | TaskDispatcher -> "TaskDispatcher"
+            | ThreadPoolDispatcher -> "ThreadPoolDispatcher"
+
+    type Duration =
+        static member nanoseconds (i: float) = i * 1.<ns>
+        static member nanoseconds (i: int) = i * 1<ns>
+        
+        static member microseconds (i: float) = i * 1.<us>
+        static member microseconds (i: int) = i * 1<us>
+        
+        static member milliseconds (i: float) = i * 1.<ms>
+        static member milliseconds (i: int) = i * 1<ms>
+        
+        static member seconds (i: float) = i * 1.<s>
+        static member seconds (i: int) = i * 1<s>
+        
+        static member minutes (i: float) = i * 1.<m>
+        static member minutes (i: int) = i * 1<m>
+        
+        static member hours (i: float) = i * 1.<h>
+        static member hours (i: int) = i * 1<h>
+        
+        static member days (i: float) = i * 1.<d>
+        static member days (i: int) = i * 1<d>
+
+    type Executor =
+        | CurrentContext
+        | Default
+        | ForkJoin
+        | Task
+        | ThreadPool
+        
+        member internal this.Text =
+            match this with
+            | CurrentContext -> "current-context-executor"
+            | Default -> "default-executor"
+            | ForkJoin -> "fork-join-executor"
+            | Task -> "task-executor"
+            | ThreadPool -> "thread-pool-executor"
+
+    type LogLevel =
+        | DEBUG
+        | ERROR
+        | INFO
+        | OFF
+        | WARNING
+
+        member internal this.Text =
+            match this with
+            | DEBUG -> "DEBUG"
+            | ERROR -> "ERROR"
+            | INFO -> "INFO"
+            | OFF -> "OFF"
+            | WARNING -> "WARNING"
+
+    type MetricSelection =
+        | CPU
+        | Heap
+        | Load
+        | Mix
+
+        member internal this.Text =
+            match this with
+            | CPU -> "cpu"
+            | Heap -> "heap"
+            | Load -> "load"
+            | Mix -> "mix"
+            
+    module Remoting =
+        type CertificateFlags =
+            | Default
+            | Exportable
+            | Machine
+            | Persist
+            | User
+            | UserProtected
+            
+            member internal this.Text =
+                match this with
+                | Default -> "default-key-set"
+                | Exportable -> "exportable"
+                | Machine -> "machine-key-set"
+                | Persist -> "persist-key-set"
+                | User -> "user-key-set"
+                | UserProtected -> "user-protected"
+
+        type StoreLocation =
+            | CurrentUser
+            | LocalMachine
+            
+            member internal this.Text =
+                match this with
+                | CurrentUser -> "current-user"
+                | LocalMachine -> "local-machine"
+    
+    [<RequireQualifiedAccess>]
+    module ReplayFilter =
+        type Mode =
+            /// Fail the replay, error is logged
+            | Fail
+            /// Disable this feature completely
+            | Off
+            /// Discard events from old writers, warning is logged
+            | RepairByDiscardOld
+            /// Log warning but emit events untouched
+            | Warn
+
+            member internal this.Text =
+                match this with
+                | Fail -> "fail"
+                | Off -> "off"
+                | RepairByDiscardOld -> "repair-by-discard-old"
+                | Warn -> "warn"
+
+    module Router =
+        type LoadBalance =
+            | Broadcast
+            | FromCode
+            | Random
+            | RoundRobin
+            | ScatterGather
+            | SmallestMailbox
+            
+            member internal this.Text =
+                match this with
+                | Broadcast -> "broadcast"
+                | FromCode -> "from-code"
+                | Random -> "random"
+                | RoundRobin -> "round-robin"
+                | ScatterGather -> "scatter-gather"
+                | SmallestMailbox -> "smallest-mailbox"
+
+        type Logic =
+            | Broadcast
+            | Random
+            | RoundRobin
+
+            member internal this.Text =
+                match this with
+                | Broadcast -> "broadcast"
+                | Random -> "random"
+                | RoundRobin -> "round-robin"
+
+    module SplitBrainResolver =
+        type Strategy =
+            | KeepMajority
+            | KeepOldest
+            | KeepReferee
+            | StaticQuorum
+            
+            member internal this.Text =
+                match this with
+                | KeepMajority -> "keep-majority"
+                | KeepOldest -> "keep-oldest"
+                | KeepReferee -> "keep-referee"
+                | StaticQuorum -> "static-quorum"
+    
+    [<RequireQualifiedAccess>]
+    module SubscriptionTimeout =
+        type Mode =
+            | Cancel
+            | Noop
+            | Warn
+            
+            member internal this.Text =
+                match this with
+                | Cancel -> "cancel"
+                | Noop -> "noop"
+                | Warn -> "warn"
+
+    type TaskPeekingMode =
+        | FIFO
+        | LIFO
+
+        member internal this.Text =
+            match this with
+            | FIFO -> "FIFO"
+            | LIFO -> "LIFO"
+
+    type ThreadType =
+        | Background
+        | Foreground
+            
+        member internal this.Text =
+            match this with
+            | Background -> "background"
+            | Foreground -> "foreground"

--- a/tests/Akkling.Tests/Akkling.Tests.fsproj
+++ b/tests/Akkling.Tests/Akkling.Tests.fsproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Akkling.Cluster.Sharding\Akkling.Cluster.Sharding.fsproj" />
     <ProjectReference Include="..\..\src\Akkling.DistributedData\Akkling.DistributedData.fsproj" />
+    <ProjectReference Include="..\..\src\Akkling.Hocon\Akkling.Hocon.fsproj" />
     <ProjectReference Include="..\..\src\Akkling.Persistence\Akkling.Persistence.fsproj" />
     <ProjectReference Include="..\..\src\Akkling.Streams.TestKit\Akkling.Streams.TestKit.fsproj" />
     <ProjectReference Include="..\..\src\Akkling.Streams\Akkling.Streams.fsproj" />

--- a/tests/Akkling.Tests/Configuration.fs
+++ b/tests/Akkling.Tests/Configuration.fs
@@ -8,6 +8,7 @@
 module Akkling.Tests.Configuration
 
 open Akkling
+open Akkling.Hocon
 open System
 open Xunit
 open Akka.Configuration
@@ -15,6 +16,27 @@ open Akka.Configuration
 type MyEnum =
     | A = 1
     | B = 2
+
+let ceConfig =
+    akka {
+        actor {
+            debug {
+                autoreceive true
+            }
+
+            default_dispatcher {
+                executor "hello"
+            }
+        }
+        "multi-part-property = 999999999999"
+        "an-integer = 1"
+        "some-strange-float = 2.5"
+        logger_async_start true
+        loggers [ "hello"; "hocon" ]
+        logger_startup_timeout 30<s>
+        "option-type = b"
+    }
+    |> Configuration.parse
 
 let config = Configuration.parse """
 outer {
@@ -39,66 +61,477 @@ outer {
 [<Fact>]
 let ``Dynamic config operation must return Config`` () = 
     let c1 = config?outer 
+    let c2 = ceConfig?akka
+    
     let (value: Config) = c1?Inner?Inner2
+    let (value2: Config) = c2?actor?debug
+
     equals typeof<Config> <| value.GetType()
+    equals typeof<Config> <| value2.GetType()
+    
     equals true <| value.HasPath "my-prop"
+    equals true <| value2.HasPath "autoreceive"
 
 [<Fact>]
 let ``Dynamic config operation must return string`` () = 
     let c1 = config?outer 
+    let c2 = ceConfig?akka
+
     let (value: string) = c1?Inner?Inner2?MyProp
+    let (value2: string) = c2?actor?DefaultDispatcher?executor
+
     equals "hello" value
+    equals "hello" value2
 
 [<Fact>]
 let ``Dynamic config operation must return int32`` () = 
     let c1 = config?outer 
+    let c2 = ceConfig?akka
+
     let (value: int) = c1?AnInteger
+    let (value2: int) = c2?AnInteger
+
     equals 1 value
+    equals 1 value2
 
 [<Fact>]
 let ``Dynamic config operation must return int64`` () = 
-    let c1 = config?outer 
+    let c1 = config?outer
+    let c2 = ceConfig?akka
+
     let (value: int64) = c1?MultiPartProperty
+    let (value2: int64) = c2?MultiPartProperty
+
     equals 999999999999L value
+    equals 999999999999L value2
 
 [<Fact>]
 let ``Dynamic config operation must return bool`` () = 
-    let c1 = config?outer 
+    let c1 = config?outer
+    let c2 = ceConfig?akka
+    
     let (value: bool) = c1?ABoolean
+    let (value2: bool) = c2?LoggerAsyncStart
+
     equals true value
+    equals true value2
 
 [<Fact>]
 let ``Dynamic config operation must return TimeSpan`` () = 
     let c1 = config?outer 
+    let c2 = ceConfig?akka
+
     let (value: TimeSpan) = c1?ATime
+    let (value2: TimeSpan) = c2?LoggerStartupTimeout
+
     equals (TimeSpan.FromSeconds 30.) value
+    equals (TimeSpan.FromSeconds 30.) value2    
 
 [<Fact>]
 let ``Dynamic config operation must return float`` () = 
     let c1 = config?outer 
+    let c2 = ceConfig?akka
+
     let (value: float32) = c1?SomeStrangeFloat
+    let (value2: float32) = c2?SomeStrangeFloat
+
     equals 2.5f value
+    equals 2.5f value2
 
 [<Fact>]
 let ``Dynamic config operation must return double`` () = 
     let c1 = config?outer 
+    let c2 = ceConfig?akka
+
     let (value: float) = c1?SomeStrangeFloat
+    let (value2: float32) = c2?SomeStrangeFloat
+
     equals 2.5 value
+    equals 2.5f value2
 
 [<Fact>]
 let ``Dynamic config operation must return decimal`` () = 
     let c1 = config?outer 
+    let c2 = ceConfig?akka
+
     let (value: decimal) = c1?SomeStrangeFloat
+    let (value2: decimal) = c2?SomeStrangeFloat
+
     equals 2.5M value
+    equals 2.5M value2
 
 [<Fact>]
 let ``Dynamic config operation must return string list`` () = 
     let c1 = config?outer 
+    let c2 = ceConfig?akka
+
     let (value: string seq) = c1?ListOfStrings
+    let (value2: string seq) = c2?loggers
+
     equals ["hello";"hocon"] <| List.ofSeq value
+    equals ["hello";"hocon"] <| List.ofSeq value2    
 
 [<Fact>]
 let ``Dynamic config operation must return an enum`` () = 
     let c1 = config?outer 
+    let c2 = ceConfig?akka
+
     let (value: MyEnum) = c1?OptionType
+    let (value2: MyEnum) = c2?OptionType
+    
     equals MyEnum.B value
+    equals MyEnum.B value2
+
+let akkaDefaultConfig () =
+    akka {
+        version 0 0 1
+        home ""
+        loggers [ "Akka.Event.DefaultLogger" ]
+        loggers_dispatcher "akka.actor.default-dispatcher"
+        logger_startup_timeout 5<s>
+        logger_async_start false
+        loglevel Hocon.LogLevel.INFO
+        "suppress-json-serializer-warning = on"
+        stdout_loglevel Hocon.LogLevel.WARNING
+        log_config_on_start false
+        log_dead_letters 10
+        log_dead_letters_during_shutdown false
+        log_dead_letters_suspend_duration 5<m>
+        extensions []
+        daemonic false
+
+        actor {
+            provider "Akka.Actor.LocalActorRefProvider"
+            guardian_supervisor_strategy "Akka.Actor.DefaultSupervisorStrategy"
+            creation_timeout 20<s>
+            reaper_interval 5
+            serialize_messages false
+            serialize_creators false
+            unstarted_push_timeout 10<s>
+            ask_timeout Hocon.infinite
+            
+            typed'.timeout 5<s>
+            
+            inbox {
+                inbox_size 1000
+                default_timeout 5<s>
+            }
+            
+            router.type_mapping {
+                from_code "Akka.Routing.NoRouter"
+                round_robin_pool "Akka.Routing.RoundRobinPool"
+                round_robin_group "Akka.Routing.RoundRobinGroup"
+                random_pool "Akka.Routing.RandomPool"
+                random_group "Akka.Routing.RandomGroup"
+                smallest_mailbox_pool "Akka.Routing.SmallestMailboxPool"
+                broadcast_pool "Akka.Routing.BroadcastPool"
+                broadcast_group "Akka.Routing.BroadcastGroup"
+                scatter_gather_pool "Akka.Routing.ScatterGatherFirstCompletedPool"
+                scatter_gather_group "Akka.Routing.ScatterGatherFirstCompletedGroup"
+                consistent_hashing_pool "Akka.Routing.ConsistentHashingPool"
+                consistent_hashing_group "Akka.Routing.ConsistentHashingGroup"
+                tail_chopping_pool "Akka.Routing.TailChoppingPool"
+                tail_chopping_group "Akka.Routing.TailChoppingGroup"
+            }
+
+            deployment {
+                default' {
+                    dispatcher ""
+                    mailbox ""
+                    router Hocon.Router.LoadBalance.FromCode
+                    nr_of_instances 1
+                    within 5<s>
+                    virtual_nodes_factor 10
+
+                    routees.paths []
+
+                    resizer {
+                        enabled false
+                        lower_bound 1
+                        upper_bound 10
+                        pressure_threshold 1
+                        rampup_rate 0.2
+                        backoff_threshold 0.3
+                        backoff_rate 0.1
+                        messages_per_resize 10
+                    }
+                }
+            }
+
+            synchronized_dispatcher {
+                type' "SynchronizedDispatcher"
+                executor "current-context-executor"
+                throughput 10
+            }
+
+            task_dispatcher {
+                type' "TaskDispatcher"
+                executor "task-executor"
+                throughput 30
+            }
+
+            default_fork_join_dispatcher {
+                type' "ForkJoinDispatcher"
+                executor "fork-join-executor"
+                throughput 30
+
+                dedicated_thread_pool {
+                    thread_count 3
+                    threadtype Hocon.ThreadType.Background
+                }
+            }
+
+            default_dispatcher {
+                type' "Dispatcher"
+                executor "default-executor"
+                
+                default_executor { "" }
+                thread_pool_executor { "" }
+                fork_join_executor {
+                    parallelism_min 8
+                    parallelism_factor 1.0
+                    parallelism_max 64
+                    task_peeking_mode Hocon.TaskPeekingMode.FIFO
+                }
+                current_context_executor { "" }
+
+                shutdown_timeout 1<s>
+                throughput 30
+                throughput_deadline_time 0<ms>
+                attempt_teamwork true
+                mailbox_requirement ""
+            }
+
+            internal_dispatcher {
+                type' "Dispatcher"
+                executor "fork-join-executor"
+                throughput 5
+
+                fork_join_executor {
+                    parallelism_min 4
+                    parallelism_factor 1.0
+                    parallelism_max 64
+                }
+            }
+
+            default_blocking_io_dispatcher {
+                type' "Dispatcher"
+                executor "thread-pool-executor"
+                throughput 1
+            }
+
+            default_mailbox {
+                mailbox_type "Akka.Dispatch.UnboundedMailbox"
+                mailbox_capacity 1000
+                mailbox_push_timeout_time 10<s>
+                stash_capacity -1
+            }
+
+            mailbox {
+                requirements [
+                    "Akka.Dispatch.IUnboundedMessageQueueSemantics" ,"akka.actor.mailbox.unbounded-queue-based"
+                    "Akka.Dispatch.IBoundedMessageQueueSemantics" ,"akka.actor.mailbox.bounded-queue-based"
+                    "Akka.Dispatch.IDequeBasedMessageQueueSemantics" ,"akka.actor.mailbox.unbounded-deque-based"
+                    "Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics" ,"akka.actor.mailbox.unbounded-deque-based"
+                    "Akka.Dispatch.IBoundedDequeBasedMessageQueueSemantics" ,"akka.actor.mailbox.bounded-deque-based"
+                    "Akka.Dispatch.IMultipleConsumerSemantics" ,"akka.actor.mailbox.unbounded-queue-based"
+                    "Akka.Event.ILoggerMessageQueueSemantics" ,"akka.actor.mailbox.logger-queue"
+                ]
+
+                unbounded_queue_based.mailbox_type "Akka.Dispatch.UnboundedMailbox"
+                bounded_queue_based.mailbox_type "Akka.Dispatch.BoundedMailbox"
+                unbounded_deque_based.mailbox_type "Akka.Dispatch.UnboundedDequeBasedMailbox"
+                bounded_deque_based.mailbox_type "Akka.Dispatch.BoundedDequeBasedMailbox"
+                logger_queue.mailbox_type "Akka.Event.LoggerMailboxType"
+            }
+
+            debug {
+                receive false
+                autoreceive false
+                lifecycle false
+                fsm false
+                event_stream false
+                router_misconfiguration false
+            }
+
+            serializers {
+                json "Akka.Serialization.NewtonSoftJsonSerializer, Akka"
+                bytes "Akka.Serialization.ByteArraySerializer, Akka"
+            }
+
+            serialization_bindings [
+                typeof<byte []>, "bytes"
+                typeof<obj>, "json"
+            ]
+
+            serialization_identifiers [
+                "Akka.Serialization.ByteArraySerializer, Akka", 4
+                "Akka.Serialization.NewtonSoftJsonSerializer, Akka", 1
+            ]
+
+            serialization_settings { "" }
+        }
+
+        scheduler {
+            tick_duration 10<ms>
+            ticks_per_wheel 512
+            implementation "Akka.Actor.HashedWheelTimerScheduler"
+            shutdown_timeout 5<s>
+        }
+
+        io {
+            
+            pinned_dispatcher {
+                type' "PinnedDispatcher"
+                executor "fork-join-executor"
+            }
+
+            let ioDirectBufferPool =
+                direct_buffer_pool {
+                    class' "Akka.IO.Buffers.DirectBufferPool, Akka"
+                    buffer_size 512
+                    buffers_per_segment 500
+                    initial_segments 1
+                    buffer_pool_limit 1024
+                }
+
+            tcp {
+                ioDirectBufferPool
+                disabled_buffer_pool {
+                    class' "Akka.IO.Buffers.DisabledBufferPool, Akka"
+                    buffer_size 512
+                }
+
+                buffer_pool "akka.io.tcp.disabled-buffer-pool"
+                max_channels 256000
+                selector_association_retries 10
+                batch_accept_limit 10
+                register_timeout 5<s>
+                max_received_message_size Hocon.unlimited
+                trace_logging false
+                
+                selector_dispatcher "akka.io.pinned-dispatcher"
+                worker_dispatcher "akka.actor.internal-dispatcher"
+                management_dispatcher "akka.actor.internal-dispatcher"
+                file_io_dispatcher "akka.actor.default-blocking-io-dispatcher"
+
+                file_io_transferTo_limit 524288
+                finish_connect_retries 5
+                windows_connection_abort_workaround_enabled false
+                outgoing_socket_force_ipv4 false
+            }
+
+            udp {
+                ioDirectBufferPool
+
+                buffer_pool "akka.io.udp.direct-buffer-pool"
+                nr_of_socket_async_event_args 32
+                max_channels 4096
+                select_timeout Hocon.infinite
+                selector_association_retries 10
+                receive_throughput 3
+                direct_buffer_size 18432
+                direct_buffer_pool_limit 1000
+                received_message_size_limit Hocon.unlimited
+                trace_logging false
+                
+                selector_dispatcher "akka.io.pinned-dispatcher"
+                worker_dispatcher "akka.actor.internal-dispatcher"
+                management_dispatcher "akka.actor.internal-dispatcher"
+            }
+
+            udp_connected {
+                ioDirectBufferPool
+
+                buffer_pool "akka.io.udp-connected.direct-buffer-pool"
+                nr_of_socket_async_event_args 32
+                max_channels 4096
+                select_timeout Hocon.infinite
+                selector_association_retries 10
+                receive_throughput 3
+                direct_buffer_size 18432
+                direct_buffer_pool_limit 1000
+                received_message_size_limit Hocon.unlimited
+                trace_logging false
+                
+                selector_dispatcher "akka.io.pinned-dispatcher"
+                worker_dispatcher "akka.actor.internal-dispatcher"
+                management_dispatcher "akka.actor.internal-dispatcher"
+            }
+
+            dns {
+                dispatcher "akka.actor.internal-dispatcher"
+                resolver "inet-address"
+
+                inet_address {
+                    provider_object "Akka.IO.InetAddressDnsProvider"
+
+                    positive_ttl 30<s>
+                    negative_ttl 10<s>
+
+                    cache_cleanup_interval 120<s>
+
+                    use_ipv6 true
+                }
+            }
+        }
+
+        coordinated_shutdown {
+            default_phase_timeout 5<s>
+            terminate_actor_system true
+            exit_clr false
+            run_by_clr_shutdown_hook true
+            run_by_actor_system_terminate true
+
+            phases {
+                before_service_unbind { "" }
+                service_unbind.depends_on [ before_service_unbind ]
+                service_stop.depends_on [ service_requests_done ]
+                before_cluster_shutdown.depends_on [ service_stop ]
+                
+                cluster_sharding_shutdown_region {
+                    timeout 10<s>
+                    depends_on [ before_cluster_shutdown ]
+                }
+                
+                cluster_leave.depends_on [ cluster_sharding_shutdown_region ]
+                
+                cluster_exiting {
+                    timeout 10<s>
+                    depends_on [ cluster_leave ]
+                }
+
+                cluster_exiting_done.depends_on [ cluster_exiting ]
+                cluster_shutdown.depends_on [ cluster_exiting_done ]
+                before_actor_system_terminate.depends_on [ cluster_shutdown ]
+
+                actor_system_terminate {
+                    timeout 10<s>
+                    depends_on [ before_actor_system_terminate ]
+                }
+            }
+        }
+    }
+    |> Configuration.parse
+
+[<Fact>]
+let ``Hocon CE builds configuration faithfully`` () =
+    // Would be nice if there was a good way to compare configs
+    // this does subscribe to fail fast and does value checks on build
+
+    //let cleanup (xs: Config) =
+    //    xs.AsEnumerable()
+    //    |> List.ofSeq
+    //    |> List.map (fun kvPair -> kvPair.Key,kvPair.Value.GetHashCode())
+    //    |> List.sort
+
+    //let def = 
+    //    Akka.Configuration.ConfigurationFactory.Default()
+    //    |> cleanup
+
+    try
+        akkaDefaultConfig()
+        |> ignore
+        true
+    with _ -> false
+    |> equals true


### PR DESCRIPTION
This PR adds computation expressions for the full (or at least what I could find, there isn't exactly a schema laying around as far as I could find) set of configuration options for Akka.NET. In addition to type safety (and UoM) and some minor niceties, it also performs checks against valid ranges (such as if a field can only be positive, or a power of two, etc).

I couldn't find a great way to test the CE in-depth, as `Config` doesn't support equality in a way that would help with this, although eye-balling it looks almost identical.