### PR TITLE
PersistentEffect: andThen operator to run custom logic after persist

### DIFF
--- a/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
+++ b/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
@@ -34,6 +34,6 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Cluster.Sharding" Version="1.4.12" />
+    <PackageReference Include="Akka.Cluster.Sharding" Version="1.4.14" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.DistributedData/Akkling.DistributedData.fsproj
+++ b/src/Akkling.DistributedData/Akkling.DistributedData.fsproj
@@ -28,6 +28,6 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.DistributedData" Version="1.4.12" />
+    <PackageReference Include="Akka.DistributedData" Version="1.4.14" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Persistence/Akkling.Persistence.fsproj
+++ b/src/Akkling.Persistence/Akkling.Persistence.fsproj
@@ -30,6 +30,6 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Persistence" Version="1.4.12" />
+    <PackageReference Include="Akka.Persistence" Version="1.4.14" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Streams.TestKit/Akkling.Streams.TestKit.fsproj
+++ b/src/Akkling.Streams.TestKit/Akkling.Streams.TestKit.fsproj
@@ -26,6 +26,6 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Streams.TestKit" Version="1.4.12" />
+    <PackageReference Include="Akka.Streams.TestKit" Version="1.4.14" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Streams/Akkling.Streams.fsproj
+++ b/src/Akkling.Streams/Akkling.Streams.fsproj
@@ -37,6 +37,6 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Streams" Version="1.4.12" />
+    <PackageReference Include="Akka.Streams" Version="1.4.14" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.TestKit/Akkling.TestKit.fsproj
+++ b/src/Akkling.TestKit/Akkling.TestKit.fsproj
@@ -25,6 +25,6 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.4.12" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.4.14" />
   </ItemGroup>
 </Project>

--- a/src/Akkling/Akkling.fsproj
+++ b/src/Akkling/Akkling.fsproj
@@ -40,7 +40,7 @@
     <Compile Include="IO.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.4.12" />
-    <PackageReference Include="Akka.Serialization.Hyperion" Version="1.4.12" />
+    <PackageReference Include="Akka" Version="1.4.14" />
+    <PackageReference Include="Akka.Serialization.Hyperion" Version="1.4.14" />
   </ItemGroup>
 </Project>

--- a/tests/Akkling.Tests/Akkling.Tests.fsproj
+++ b/tests/Akkling.Tests/Akkling.Tests.fsproj
@@ -30,8 +30,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit" Version="2.14.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Related to: https://github.com/Horusiath/Akkling/issues/142

This adds a new extra operator, `Effects.andThen`, which enables to attach an extra callback to be executed after event has been persisted and **after** actor's handler has been executed on that event.

```fsharp
let counter =
    spawn system "counter-1" <| propsPersist(fun ctx->
        let rec loop state =
            actor {
                let! msg = ctx.Receive()
                match msg with
                | Event(changed) -> return! loop (state + changed.Delta)
                | Command(cmd) ->
                    match cmd with
                    | GetState ->
                        ctx.Sender() <! state
                        return! loop state
                    | Inc -> return Persist (Event { Delta = 1 }) |> Effects.andThen (fun () -> logDebugf ctx "inc")
                    | Dec -> return Persist (Event { Delta = -1 }) |> Effects.andThen (fun () -> logDebugf ctx "dec")
            }
        loop 0)
```