### PR TITLE
Restore target framework .NET Standard 2.0.

### DIFF
--- a/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
+++ b/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>0.10.0</Version>
     <Authors>Bartosz Sypytkowski</Authors>
     <Description>F# wrapper library for Akka.NET cluster sharding module.</Description>

--- a/src/Akkling.DistributedData/Akkling.DistributedData.fsproj
+++ b/src/Akkling.DistributedData/Akkling.DistributedData.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>0.10.0</Version>
     <Authors>Bartosz Sypytkowski</Authors>
     <Description>F# wrapper library for Akka.NET with geo-replicated distributed data support (CRDT)</Description>

--- a/src/Akkling.Hocon/Akkling.Hocon.fsproj
+++ b/src/Akkling.Hocon/Akkling.Hocon.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>0.10.0</Version>
     <Authors>Bartosz Sypytkowski</Authors>
     <Description>Akka.NET HOCON computation expressions</Description>

--- a/src/Akkling.Persistence/Akkling.Persistence.fsproj
+++ b/src/Akkling.Persistence/Akkling.Persistence.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>0.10.0</Version>
     <Authors>Bartosz Sypytkowski</Authors>
     <Description>F# wrapper library for Akka.NET with persistence support</Description>

--- a/src/Akkling.Streams.TestKit/Akkling.Streams.TestKit.fsproj
+++ b/src/Akkling.Streams.TestKit/Akkling.Streams.TestKit.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>0.10.0</Version>
     <Authors>Bartosz Sypytkowski</Authors>
     <Description>F# wrapper library for Akka.NET Streams TestKit library using FsCheck and xUnit.</Description>

--- a/src/Akkling.Streams/Akkling.Streams.fsproj
+++ b/src/Akkling.Streams/Akkling.Streams.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageLicenseUrl>https://github.com/Horusiath/Akkling/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Horusiath/Akkling</PackageProjectUrl>
     <Authors>Bartosz Sypytkowski</Authors>

--- a/src/Akkling.TestKit/Akkling.TestKit.fsproj
+++ b/src/Akkling.TestKit/Akkling.TestKit.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTags>akka.net fsharp testing fscheck</PackageTags>
     <Authors>Bartosz Sypytkowski</Authors>
     <Version>0.10.0</Version>

--- a/src/Akkling/Akkling.fsproj
+++ b/src/Akkling/Akkling.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>0.10.0</Version>
     <Authors>Bartosz Sypytkowski</Authors>
     <Company />


### PR DESCRIPTION
Having given more though to the issue #140, and especially after reading the article but Immo Landwerth, I believe it will be the right thing to restore .NET Standard 2.0 as the targer for the libraries, leaving .NET 5.0 as a target for tests.

More about this (section "What You Should Target"):
https://www.codemag.com/Article/2010022/From-.NET-Standard-to-.NET-5

So here's the PR.