### PR TITLE
Move apply logic to effects

### DIFF
--- a/src/Akkling.Persistence/PersistentActor.fs
+++ b/src/Akkling.Persistence/PersistentActor.fs
@@ -155,10 +155,7 @@ and TypedPersistentContext<'Message, 'Actor when 'Actor :> FunPersistentActor<'M
             context.System.Scheduler.ScheduleTellOnceCancelable(delay, untyped target, message, self)
         member __.Incarnation() = actor :> ActorBase
         member __.Stop(ref : IActorRef<'T>) = context.Stop(untyped ref)
-        member __.Unhandled(msg) =
-            match box actor with
-            | :? FunPersistentActor<'Message> as act -> act.InternalUnhandled(msg)
-            | _ -> raise (Exception("Couldn't use actor in typed context"))
+        member __.Unhandled(msg) = actor.InternalUnhandled(msg)
         member __.Journal = actor.Journal
         member __.SnapshotStore = actor.SnapshotStore
         member __.IsRecovering () = actor.IsRecovering

--- a/src/Akkling.Persistence/PersistentActor.fs
+++ b/src/Akkling.Persistence/PersistentActor.fs
@@ -173,6 +173,7 @@ and TypedPersistentContext<'Message, 'Actor when 'Actor :> FunPersistentActor<'M
         member __.DeferEvent(events, callback) =
             let cb = if obj.ReferenceEquals(callback, Unchecked.defaultof<_>) then this.Deferring else deferring callback
             events |> Seq.iter (fun e -> actor.DeferAsync(e, cb))
+        member __.Become(effect) = actor.Become(effect)
 
 and PersistentLifecycleEvent =
     | ReplaySucceed
@@ -180,35 +181,24 @@ and PersistentLifecycleEvent =
     | PersistFailed of cause:exn * evt:obj * sequenceNr:int64
     | PersistRejected of cause:exn * evt:obj * sequenceNr:int64
     interface IDeadLetterSuppression
+    interface UnhandledSuppression
 
 and FunPersistentActor<'Message>(actor : Eventsourced<'Message> -> Effect<'Message>) as this =
     inherit UntypedPersistentActor()
     let untypedContext = UntypedActor.Context
     let ctx = TypedPersistentContext<'Message, FunPersistentActor<'Message>>(untypedContext, this)
-    let mutable behavior = actor ctx
+    let mutable behavior =
+        match actor ctx with
+        | :? Become<'Message> as effect -> effect.Effect
+        | effect -> effect
+    
+    member __.Become (effect : Effect<'Message>) = behavior <- effect
 
-    member __.Next (current : Effect<'Message>) (context : Actor<'Message>) (message : obj) : Effect<'Message> =
-        match message with
-        | :? 'Message as msg ->
-            match current with
-            | Become(fn) -> fn msg
-            | _ -> current
-        | :? LifecycleEvent | :? PersistentLifecycleEvent ->
-            // we don't treat unhandled lifecycle events as casual unhandled messages
-            current
-        | :? JObject as jobj ->
-            match current with
-            | Become(fn) -> fn <| jobj.ToObject<'Message>()
-            | _ -> current
-        | other ->
-            base.Unhandled other
-            current
-
-    member __.Handle (msg: obj) : unit =
-        let nextBehavior = this.Next behavior ctx msg
-        match nextBehavior with
-        | :? Become<'Message> -> behavior <- nextBehavior
-        | effect -> effect.OnApplied(ctx, msg :?> 'Message)
+    member __.Handle (msg: obj) =
+        match msg with
+        | Message msg -> behavior.OnApplied(ctx, msg)
+        | :? UnhandledSuppression -> ()
+        | msg -> base.Unhandled msg
 
     member __.Sender() : IActorRef = base.Sender
     member __.InternalUnhandled(message: obj) : unit = base.Unhandled message

--- a/tests/Akkling.Tests/AsyncSupport.fs
+++ b/tests/Akkling.Tests/AsyncSupport.fs
@@ -12,6 +12,7 @@ open Akkling.TestKit
 open Akka.Actor
 open System
 open Xunit
+open Akkling.Persistence
 
 [<Fact>]
 let ``actor builder supports bind to async`` () = testDefault <| fun tck ->
@@ -55,6 +56,55 @@ let ``actor supports multiple async computations`` () : unit = testDefault <| fu
                 }
             loop ())
             
+    ref <! ""
+    expectMsg tck 0 |> ignore
+    expectMsg tck 1 |> ignore
+    expectMsg tck 2 |> ignore
+    expectMsg tck 3 |> ignore    
+    expectNoMsgWithin tck (TimeSpan.FromSeconds 1.)
+    
+[<Fact>]
+let ``persistentActor builder supports bind to async`` () = testDefault <| fun tck ->
+    let ref = 
+        spawn tck "actor"
+        <| propsPersist (fun ctx ->
+            let rec loop state =
+                actor {
+                    let! msg = ctx.Receive ()
+                    let! newState = async { return state + 1 }
+                    let expected = state
+                    ctx.Sender() <! newState
+                    return! loop newState
+                }
+            loop 1)
+    ref <! ""
+    ref <! ""
+    ref <! ""
+    expectMsg tck 2 |> ignore
+    expectMsg tck 3 |> ignore
+    expectMsg tck 4 |> ignore
+    
+[<Fact>]
+let ``persistentActor supports multiple async computations`` () : unit = testDefault <| fun tck ->
+    let ref = 
+        spawn tck "actor"
+        <| propsPersist (fun ctx ->
+            let rec loop () =
+                actor {
+                    let! _ = ctx.Receive()
+                    ctx.Sender() <! 0
+                    do! Async.Sleep 1
+                    ctx.Sender() <! 1
+                    do! Async.Sleep 1
+                    let! x = async { return 2 }
+                    ctx.Sender() <! x
+                    do! Async.Sleep 1
+                    let! x = async { return 3 }
+                    ctx.Sender() <! x
+                    return! loop ()
+                }
+            loop ())
+                
     ref <! ""
     expectMsg tck 0 |> ignore
     expectMsg tck 1 |> ignore

--- a/tests/Akkling.Tests/Tests.fs
+++ b/tests/Akkling.Tests/Tests.fs
@@ -14,3 +14,7 @@ open Xunit
 let equals (expected: 'a) (value: 'a) = Assert.Equal<'a>(expected, value) 
 let success = ()
 
+let (|String|_|) (message: obj) =
+    match message with
+    | :? string as x -> Some x
+    | _ -> None


### PR DESCRIPTION
This PR moves the apply logic of the `Become` and `Async` effects to themselves.

This reduces the knowledge of the actors regarding the specific effects and make it possible to apply the effect outside the actor.

This is specially useful for `CombinedEffect`, which couldn't combine the `Become` or the `Async` effect with another effect - which was the way I figured to fix the issues I've found in #147 - because those effects were handled inside the actors.

Also, it adds support to `Async` effects in persistent actors, as the persistent actor wasn't handling the `Async.

Besides, I created a new `UnhandledSuppression` marker interface, which makes the messages of this type not call the `Unhandled` if they aren't handled. That means we don't need different code to handle message in regular actors and persistent actors anymore. They are exactly the same.