### PR TITLE
Better async support

### DIFF
--- a/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
+++ b/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
@@ -33,5 +33,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Akka.Cluster.Sharding" Version="1.4.27" />
+    <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.DistributedData/Akkling.DistributedData.fsproj
+++ b/src/Akkling.DistributedData/Akkling.DistributedData.fsproj
@@ -27,5 +27,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Akka.DistributedData" Version="1.4.27" />
+    <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Hocon/Akkling.Hocon.fsproj
+++ b/src/Akkling.Hocon/Akkling.Hocon.fsproj
@@ -66,5 +66,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Akka" Version="1.4.27" />
+    <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Persistence/Akkling.Persistence.fsproj
+++ b/src/Akkling.Persistence/Akkling.Persistence.fsproj
@@ -29,5 +29,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Akka.Persistence" Version="1.4.27" />
+    <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Streams.TestKit/Akkling.Streams.TestKit.fsproj
+++ b/src/Akkling.Streams.TestKit/Akkling.Streams.TestKit.fsproj
@@ -25,5 +25,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Akka.Streams.TestKit" Version="1.4.27" />
+    <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Streams/Akkling.Streams.fsproj
+++ b/src/Akkling.Streams/Akkling.Streams.fsproj
@@ -36,5 +36,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Akka.Streams" Version="1.4.27" />
+    <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.TestKit/Akkling.TestKit.fsproj
+++ b/src/Akkling.TestKit/Akkling.TestKit.fsproj
@@ -24,5 +24,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Akka.TestKit.Xunit2" Version="1.4.27" />
+    <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling/ActorBuilder.fs
+++ b/src/Akkling/ActorBuilder.fs
@@ -10,6 +10,7 @@
 module Akkling.ComputationExpressions
 
 open System
+open System.Threading.Tasks
 
 /// Gives access to the next message throu let! binding in actor computation expression.
 //type Behavior<'In, 'Out> = 
@@ -27,6 +28,16 @@ type ActorBuilder() =
         upcast AsyncEffect (async {
             let! returned = asyncInput 
             return continuation returned 
+        })
+    member __.Bind(taskInput: Task<'In>, continuation: 'In -> Effect<'Out>) : Effect<'Out> =
+        upcast TaskEffect (task {
+            let! returned = taskInput
+            return continuation returned
+        })
+    member __.Bind(taskInput: Task, continuation: unit -> Effect<'Out>) : Effect<'Out> =
+        upcast TaskEffect (task {
+            do! taskInput
+            return continuation ()
         })
     member __.ReturnFrom (effect: Effect<'Message>) = effect
     member __.Return (value: Effect<'Message>) : Effect<'Message> = value

--- a/src/Akkling/Akkling.fsproj
+++ b/src/Akkling/Akkling.fsproj
@@ -40,5 +40,6 @@
   <ItemGroup>
     <PackageReference Include="Akka" Version="1.4.27" />
     <PackageReference Include="Akka.Serialization.Hyperion" Version="1.4.27" />
+    <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/tests/Akkling.Tests/Akkling.Tests.fsproj
+++ b/tests/Akkling.Tests/Akkling.Tests.fsproj
@@ -33,5 +33,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR fixes a bug with async workflows within persistent actors.
The actor was throwing an exception when the Persist effect was applied due to it being executed in a different thread.

Since to fix the bug the F# 6 task CE had to be used, I went ahead and introduced task support to actors as well.