### PR TITLE
Add support for Akka 1.5

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "6.0.114",
     "rollForward" : "minor"
   }
 }

--- a/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
+++ b/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
@@ -32,7 +32,7 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Cluster.Sharding" Version="1.4.27" />
+    <PackageReference Include="Akka.Cluster.Sharding" Version="1.5.0" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Cluster.Sharding/ClusterSingleton.fs
+++ b/src/Akkling.Cluster.Sharding/ClusterSingleton.fs
@@ -18,7 +18,7 @@ open Akkling
 /// Spawns an actor in cluster singleton mode.
 /// </summary>
 /// <param name="stopMessage">Message used to stop an actor</param>
-/// <param name="factory">Actor system used to spawn an actor</param>
+/// <param name="system">Actor system used to spawn an actor</param>
 /// <param name="name">Actor singleton name.</param>
 /// <param name="props">Props used to build an actor.</param>
 let spawnSingleton (stopMessage: obj) (system: ActorSystem) (name: string) (props: Props<'Message>) : IActorRef<'Message> =

--- a/src/Akkling.DistributedData/Akkling.DistributedData.fsproj
+++ b/src/Akkling.DistributedData/Akkling.DistributedData.fsproj
@@ -26,7 +26,7 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.DistributedData" Version="1.4.27" />
+    <PackageReference Include="Akka.DistributedData" Version="1.5.0" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Hocon/Akkling.Hocon.fsproj
+++ b/src/Akkling.Hocon/Akkling.Hocon.fsproj
@@ -65,7 +65,7 @@
     <Compile Include="Akka.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.4.46" />
+    <PackageReference Include="Akka" Version="1.5.0" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Persistence/Akkling.Persistence.fsproj
+++ b/src/Akkling.Persistence/Akkling.Persistence.fsproj
@@ -28,7 +28,7 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Persistence" Version="1.4.27" />
+    <PackageReference Include="Akka.Persistence" Version="1.5.0" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Streams.TestKit/Akkling.Streams.TestKit.fsproj
+++ b/src/Akkling.Streams.TestKit/Akkling.Streams.TestKit.fsproj
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Streams.TestKit" Version="1.4.27" />
+    <PackageReference Include="Akka.Streams.TestKit" Version="1.5.0" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Streams/Akkling.Streams.fsproj
+++ b/src/Akkling.Streams/Akkling.Streams.fsproj
@@ -35,7 +35,7 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Streams" Version="1.4.27" />
+    <PackageReference Include="Akka.Streams" Version="1.5.0" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Streams/Graph.fs
+++ b/src/Akkling.Streams/Graph.fs
@@ -38,7 +38,7 @@ module Graph =
         GraphDsl.Create(shape1, shape2, shape3, shape4, shape5, Func<_,_,_,_,_,_>(combineFn), Func<_,_,_,_,_,_,_>(builder))
 
     /// Executes provided graph using provided materializer.
-    let run (mat: #IMaterializer) (graph: #IRunnableGraph<'mat>) =
+    let run (mat: IMaterializer) (graph: #IRunnableGraph<'mat>) =
         graph.Run mat
 
     /// Transform only the materialized value of this RunnableGraph, leaving all other properties as they were.

--- a/src/Akkling.Streams/Prolog.fs
+++ b/src/Akkling.Streams/Prolog.fs
@@ -24,7 +24,7 @@ module Prolog =
     
     let inline toCsOption (o: 'v option) : Akka.Util.Option<'v> =
         match o with
-        | Some v -> Akka.Util.Option<'v>(v)
+        | Some v -> Akka.Util.Option.Create(v)
         | None -> Akka.Util.Option<'v>.None
             
     let inline ofCsOption (o: Akka.Util.Option<'v>) = if o.HasValue then Some o.Value else None

--- a/src/Akkling.Streams/Sink.fs
+++ b/src/Akkling.Streams/Sink.fs
@@ -48,18 +48,18 @@ module Sink =
     let inline fanoutPublisher<'t> : Sink<'t, IPublisher<'t>> = Sink.FanoutPublisher<'t>()
 
     /// A sink that will consume the stream and discard the elements.
-    let inline ignore<'t> : Sink<'t, Async<unit>> = Sink.Ignore<'t>().MapMaterializedValue(Func<_,_>(Async.AwaitTask))
+    let inline ignore<'t> : Sink<'t, Async<Akka.Done>> = Sink.Ignore<'t>().MapMaterializedValue(Func<_,_>(Async.AwaitTask))
 
     /// A sink that will invoke the given function for each received element. 
     /// The sink is materialized into an Async computation will be completed with success when reaching the
     /// normal end of the stream, or completed with a failure if there is a failure signaled in
     /// the stream.
-    let inline forEach (fn: 't -> unit) : Sink<'t, Async<unit>> = Sink.ForEach(Action<_>(fn)).MapMaterializedValue(Func<_,_>(Async.AwaitTask))
+    let inline forEach (fn: 't -> unit) : Sink<'t, Async<Akka.Done>> = Sink.ForEach(Action<_>(fn)).MapMaterializedValue(Func<_,_>(Async.AwaitTask))
 
     /// A sink that will invoke the given function 
     /// to each of the elements as they pass in. 
     /// The sink is materialized into an Async computation.
-    let inline forEachParallel (parallelism: int) (fn: 't -> unit) : Sink<'t, Async<unit>> = Sink.ForEachParallel(parallelism, Action<_>(fn)).MapMaterializedValue(Func<_,_>(Async.AwaitTask))
+    let inline forEachParallel (parallelism: int) (fn: 't -> unit) : Sink<'t, Async<Akka.Done>> = Sink.ForEachParallel(parallelism, Action<_>(fn)).MapMaterializedValue(Func<_,_>(Async.AwaitTask))
 
     /// A sink that will invoke the given folder function for every received element, 
     /// giving it its previous output (or the given zero value) and the element as input.

--- a/src/Akkling.Streams/SubFlow.fs
+++ b/src/Akkling.Streams/SubFlow.fs
@@ -366,7 +366,7 @@ module SubFlow =
     /// The task completes with success when received complete message from upstream or cancel
     /// from downstream. It fails with the same error when received error message from
     /// downstream.
-    let inline watchTermination (matFn: 'mat -> Async<unit> -> 'mat2) (subFlow) : SubFlow<_, _, 'mat2> =
+    let inline watchTermination (matFn: 'mat -> Async<Akka.Done> -> 'mat2) (subFlow) : SubFlow<_, _, 'mat2> =
         SubFlowOperations.WatchTermination(subFlow, Func<_,_,_>(fun m t -> matFn m (t |> Async.AwaitTask)))
 
     /// Detaches upstream demand from downstream demand without detaching the

--- a/src/Akkling.TestKit/Akkling.TestKit.fsproj
+++ b/src/Akkling.TestKit/Akkling.TestKit.fsproj
@@ -23,7 +23,7 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.4.27" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.5.0" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling/Actors.fs
+++ b/src/Akkling/Actors.fs
@@ -78,17 +78,17 @@ type Actor<'Message> =
     abstract UnstashAll : unit -> unit
     
     /// <summary>
-    /// Sets or clears a timeout before <see="ReceiveTimeout"/> message will be send to an actor.
+    /// Sets or clears a timeout before <see cref="ReceiveTimeout"/> message will be send to an actor.
     /// </summary>
     abstract SetReceiveTimeout : TimeSpan option -> unit
     
     /// <summary>
-    /// Schedules a message to be transmited in specified delay.
+    /// Schedules a message to be transmitted in specified delay.
     /// </summary>
     abstract Schedule<'Scheduled> : TimeSpan -> IActorRef<'Scheduled> -> 'Scheduled -> ICancelable
     
     /// <summary>
-    /// Schedules a message to be repeatedly transmited, starting at specified delay with provided intervals.
+    /// Schedules a message to be repeatedly transmitted, starting at specified delay with provided intervals.
     /// </summary>
     abstract ScheduleRepeatedly<'Scheduled> : TimeSpan -> TimeSpan -> IActorRef<'Scheduled> -> 'Scheduled -> ICancelable
 

--- a/src/Akkling/Akkling.fsproj
+++ b/src/Akkling/Akkling.fsproj
@@ -38,8 +38,8 @@
     <Compile Include="IO.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.4.46" />
-    <PackageReference Include="Akka.Serialization.Hyperion" Version="1.4.27" />
+    <PackageReference Include="Akka" Version="1.5.0" />
+    <PackageReference Include="Akka.Serialization.Hyperion" Version="1.5.0" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/tests/Akkling.Tests/Akkling.Tests.fsproj
+++ b/tests/Akkling.Tests/Akkling.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Akkling.Tests/Akkling.Tests.fsproj
+++ b/tests/Akkling.Tests/Akkling.Tests.fsproj
@@ -30,9 +30,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit" Version="2.14.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Akka 1.5 introduced a few changes (in Logging, TestKit and Akka Streams) that broke backward compatibility on a binary level. 

Here are example of runtime errors caused by the breaking changes:

1. Akka.Actor.ActorInitializationException: Exception during creation
 ---> System.TypeLoadException: Error while creating actor instance of type Akkling.Actors+FunActor`1[System.Object] with 1 args
 ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.MissingMethodException: Method not found: 'Void Akka.Event.ILoggingAdapter.Log(Akka.Event.LogLevel, System.String, System.Object[])'.

2. System.MissingMethodException: Method not found: 'Void Akka.TestKit.TestKitBase.ExpectNoMsg(System.TimeSpan)'

3. Method not found: 'Void Akka.TestKit.TestKitBase.ExpectNoMsg(System.TimeSpan)'

Most of the changes however are source compatible and only requires rebuilding Akkling with references to Akka 1.5 libraries.

This PR rebuilds Akkling using Akka 1.5 libraries.