### PR TITLE
Revise I/O TCP example

### DIFF
--- a/examples/io.fsx
+++ b/examples/io.fsx
@@ -1,4 +1,3 @@
-#r "nuget: Akka.Serialization.Hyperion"
 #r "nuget: Akkling"
 
 open System
@@ -6,17 +5,19 @@ open Akkling
 open Akkling.IO
 open Akkling.IO.Tcp
 open System.Net
+
 let system = System.create "telnet-sys" <| Configuration.defaultConfig()
+
 let handler connection = fun (ctx: Actor<obj>) ->
     monitor ctx connection |> ignore
     let rec loop () = actor {
         let! msg = ctx.Receive ()
         match msg with
         | Received(data) ->
-            printfn "%s" (string data)
+            ctx.Sender() <! TcpMessage.Write(ByteString.ofUtf8String("ACK: " + (string data)))
             return! loop ()
-        | Terminated(_, _,_) | ConnectionClosed(_) -> return Stop
-        | _ -> return Unhandled
+        | Terminated(_, _, _) | ConnectionClosed(_) -> return Stop
+        | _ -> return Ignore
     }
     loop ()
 
@@ -30,6 +31,37 @@ let listener = spawn system "listener" <| props(fun m ->
             let conn = m.Sender ()
             conn <! TcpMessage.Register(untyped (spawn m null (props(handler conn))))
             return! loop ()
-        | _ -> return Unhandled
+        | _ -> return Ignore
     }
     loop ())
+
+
+// Ex: Initiate connection & communication via a client
+//     existing outside the actor system.
+
+open System.Text
+open System.Threading.Tasks
+open System.Net.Sockets
+
+let echo (msg: string) = task {
+    use client = new TcpClient()
+    do! client.ConnectAsync(endpoint)
+    use stream = client.GetStream()
+
+    do! stream.WriteAsync(Encoding.UTF8.GetBytes msg)
+
+    let buffer = Array.create 1024 (byte 1)
+    let! received = stream.ReadAsync buffer
+    let result = Encoding.UTF8.GetString(buffer, 0, received)
+
+    printfn "Client request result: %A" result
+}
+
+Task.Delay(1500).Wait()
+(echo "big fish").Wait()
+(echo "small fish").Wait()
+
+// Alternatively, use telnet from the console:
+// > telnet 127.0.0.1 5000
+// > starfish
+// > ACK: starfish


### PR DESCRIPTION
- Fix Unhandled effect causing Bound and LifeCycle events to be sent to DeadLetters
- Add TCP client to demonstrate connecting & sending messages to TCP server