### PR TITLE
Update Akka.NET packages to version 1.5.15 and revise TypedMessageExtractor

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+## New in 0.14 (Released 2024/01/11)
+* Upgraded Akka.NET dependencies to 1.5.15
+* Revised internal TypedMessageExtractor type to support new version of IMessageExtractor
+* Updated Xunit packages
+
 ## New in 0.13 (Released 2023/03/11)
 * Upgraded Akka.NET dependencies to 1.5
 

--- a/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
+++ b/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Cluster.Sharding" Version="1.5.0" />
+    <PackageReference Include="Akka.Cluster.Sharding" Version="1.5.15" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
+++ b/src/Akkling.Cluster.Sharding/Akkling.Cluster.Sharding.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <Version>0.13.0</Version>
+    <Version>0.14.0</Version>
     <Authors>Bartosz Sypytkowski</Authors>
     <Description>F# wrapper library for Akka.NET cluster sharding module.</Description>
     <PackageLicenseUrl>https://github.com/Horusiath/Akkling/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/Akkling.Cluster.Sharding/ClusterClient.fs
+++ b/src/Akkling.Cluster.Sharding/ClusterClient.fs
@@ -2,7 +2,7 @@
 // <copyright file="ClusterClient.fs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
-//     Copyright (C) 2016-2020 Bartosz Sypytkowski <gttps://github.com/Horusiath>
+//     Copyright (C) 2016-2024 Bartosz Sypytkowski <gttps://github.com/Horusiath>
 // </copyright>
 //-----------------------------------------------------------------------
 

--- a/src/Akkling.Cluster.Sharding/ClusterExtensions.fs
+++ b/src/Akkling.Cluster.Sharding/ClusterExtensions.fs
@@ -2,7 +2,7 @@
 // <copyright file="ClusterExtensions.fs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
-//     Copyright (C) 2016-2020 Bartosz Sypytkowski <gttps://github.com/Horusiath>
+//     Copyright (C) 2016-2024 Bartosz Sypytkowski <gttps://github.com/Horusiath>
 // </copyright>
 //-----------------------------------------------------------------------
 

--- a/src/Akkling.Cluster.Sharding/ClusterSingleton.fs
+++ b/src/Akkling.Cluster.Sharding/ClusterSingleton.fs
@@ -2,7 +2,7 @@
 // <copyright file="ClusterSingleton.fs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
-//     Copyright (C) 2016-2020 Bartosz Sypytkowski <gttps://github.com/Horusiath>
+//     Copyright (C) 2016-2024 Bartosz Sypytkowski <gttps://github.com/Horusiath>
 // </copyright>
 //-----------------------------------------------------------------------
 

--- a/src/Akkling.Cluster.Sharding/DistributedPubSub.fs
+++ b/src/Akkling.Cluster.Sharding/DistributedPubSub.fs
@@ -2,7 +2,7 @@
 // <copyright file="DistributedPubSub.fs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
-//     Copyright (C) 2016-2020 Bartosz Sypytkowski <gttps://github.com/Horusiath>
+//     Copyright (C) 2016-2024 Bartosz Sypytkowski <gttps://github.com/Horusiath>
 // </copyright>
 //-----------------------------------------------------------------------
 

--- a/src/Akkling.Cluster.Sharding/EntityRef.fs
+++ b/src/Akkling.Cluster.Sharding/EntityRef.fs
@@ -2,7 +2,7 @@
 // <copyright file="ClusterSharding.fs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
-//     Copyright (C) 2016-2020 Bartosz Sypytkowski <gttps://github.com/Horusiath>
+//     Copyright (C) 2016-2024 Bartosz Sypytkowski <gttps://github.com/Horusiath>
 // </copyright>
 //-----------------------------------------------------------------------
 

--- a/src/Akkling.DistributedData/Akkling.DistributedData.fsproj
+++ b/src/Akkling.DistributedData/Akkling.DistributedData.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <Version>0.13.0</Version>
+    <Version>0.14.0</Version>
     <Authors>Bartosz Sypytkowski</Authors>
     <Description>F# wrapper library for Akka.NET with geo-replicated distributed data support (CRDT)</Description>
     <PackageProjectUrl>https://github.com/Horusiath/Akkling</PackageProjectUrl>

--- a/src/Akkling.DistributedData/Akkling.DistributedData.fsproj
+++ b/src/Akkling.DistributedData/Akkling.DistributedData.fsproj
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.DistributedData" Version="1.5.0" />
+    <PackageReference Include="Akka.DistributedData" Version="1.5.15" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.DistributedData/Collections.fs
+++ b/src/Akkling.DistributedData/Collections.fs
@@ -2,7 +2,7 @@
 // <copyright file="Collections.fs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
-//     Copyright (C) 2016-2020 Bartosz Sypytkowski <gttps://github.com/Horusiath>
+//     Copyright (C) 2016-2024 Bartosz Sypytkowski <gttps://github.com/Horusiath>
 // </copyright>
 //-----------------------------------------------------------------------
 

--- a/src/Akkling.DistributedData/Consistency.fs
+++ b/src/Akkling.DistributedData/Consistency.fs
@@ -2,7 +2,7 @@
 // <copyright file="Consistency.fs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
-//     Copyright (C) 2016-2020 Bartosz Sypytkowski <gttps://github.com/Horusiath>
+//     Copyright (C) 2016-2024 Bartosz Sypytkowski <gttps://github.com/Horusiath>
 // </copyright>
 //-----------------------------------------------------------------------
 

--- a/src/Akkling.DistributedData/DData.fs
+++ b/src/Akkling.DistributedData/DData.fs
@@ -2,7 +2,7 @@
 // <copyright file="DData.fs" company="Akka.NET Project">
 //     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 //     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
-//     Copyright (C) 2016-2020 Bartosz Sypytkowski <gttps://github.com/Horusiath>
+//     Copyright (C) 2016-2024 Bartosz Sypytkowski <gttps://github.com/Horusiath>
 // </copyright>
 //-----------------------------------------------------------------------
 

--- a/src/Akkling.Hocon/Akkling.Hocon.fsproj
+++ b/src/Akkling.Hocon/Akkling.Hocon.fsproj
@@ -63,7 +63,7 @@
     <Compile Include="Akka.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.5.0" />
+    <PackageReference Include="Akka" Version="1.5.15" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Hocon/Akkling.Hocon.fsproj
+++ b/src/Akkling.Hocon/Akkling.Hocon.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <Version>0.13.0</Version>
+    <Version>0.14.0</Version>
     <Authors>Bartosz Sypytkowski</Authors>
     <Description>Akka.NET HOCON computation expressions</Description>
     <PackageProjectUrl>https://github.com/Horusiath/Akkling</PackageProjectUrl>

--- a/src/Akkling.Persistence/Akkling.Persistence.fsproj
+++ b/src/Akkling.Persistence/Akkling.Persistence.fsproj
@@ -26,7 +26,7 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Persistence" Version="1.5.0" />
+    <PackageReference Include="Akka.Persistence" Version="1.5.15" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Persistence/Akkling.Persistence.fsproj
+++ b/src/Akkling.Persistence/Akkling.Persistence.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <Version>0.13.0</Version>
+    <Version>0.14.0</Version>
     <Authors>Bartosz Sypytkowski</Authors>
     <Description>F# wrapper library for Akka.NET with persistence support</Description>
     <PackageLicenseUrl>https://github.com/Horusiath/Akkling/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/Akkling.Streams.TestKit/Akkling.Streams.TestKit.fsproj
+++ b/src/Akkling.Streams.TestKit/Akkling.Streams.TestKit.fsproj
@@ -22,7 +22,7 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Streams.TestKit" Version="1.5.0" />
+    <PackageReference Include="Akka.Streams.TestKit" Version="1.5.15" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.Streams.TestKit/Akkling.Streams.TestKit.fsproj
+++ b/src/Akkling.Streams.TestKit/Akkling.Streams.TestKit.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <Version>0.13.0</Version>
+    <Version>0.14.0</Version>
     <Authors>Bartosz Sypytkowski</Authors>
     <Description>F# wrapper library for Akka.NET Streams TestKit library using FsCheck and xUnit.</Description>
     <PackageTags>akka.net streams fsharp testing fscheck reactive streams</PackageTags>

--- a/src/Akkling.Streams/Akkling.Streams.fsproj
+++ b/src/Akkling.Streams/Akkling.Streams.fsproj
@@ -5,7 +5,7 @@
     <PackageLicenseUrl>https://github.com/Horusiath/Akkling/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Horusiath/Akkling</PackageProjectUrl>
     <Authors>Bartosz Sypytkowski</Authors>
-    <Version>0.13.0</Version>
+    <Version>0.14.0</Version>
     <Description>F# wrapper library for Akka.NET with reactive streams support</Description>
     <PackageTags>akka.net fsharp reactive streams</PackageTags>
     <PackageReleaseNotes>

--- a/src/Akkling.Streams/Akkling.Streams.fsproj
+++ b/src/Akkling.Streams/Akkling.Streams.fsproj
@@ -33,7 +33,7 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Streams" Version="1.5.0" />
+    <PackageReference Include="Akka.Streams" Version="1.5.15" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.TestKit/Akkling.TestKit.fsproj
+++ b/src/Akkling.TestKit/Akkling.TestKit.fsproj
@@ -21,7 +21,7 @@
     <ProjectReference Include="..\Akkling\Akkling.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.5.0" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.5.15" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling.TestKit/Akkling.TestKit.fsproj
+++ b/src/Akkling.TestKit/Akkling.TestKit.fsproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <PackageTags>akka.net fsharp testing fscheck</PackageTags>
     <Authors>Bartosz Sypytkowski</Authors>
-    <Version>0.13.0</Version>
+    <Version>0.14.0</Version>
     <Description>F# wrapper library for Akka.NET TestKit library using FsCheck and xUnit.</Description>
     <PackageLicenseUrl>https://github.com/Horusiath/Akkling/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Horusiath/Akkling</PackageProjectUrl>

--- a/src/Akkling/Akkling.fsproj
+++ b/src/Akkling/Akkling.fsproj
@@ -36,8 +36,8 @@
     <Compile Include="IO.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.5.0" />
-    <PackageReference Include="Akka.Serialization.Hyperion" Version="1.5.0" />
+    <PackageReference Include="Akka" Version="1.5.15" />
+    <PackageReference Include="Akka.Serialization.Hyperion" Version="1.5.15" />
     <PackageReference Update="FSharp.Core" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Akkling/Akkling.fsproj
+++ b/src/Akkling/Akkling.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <Version>0.13.0</Version>
+    <Version>0.14.0</Version>
     <Authors>Bartosz Sypytkowski</Authors>
     <Company />
     <Description>Library used for working with Akka.NET using F# in type safe manner with functional principles in mind</Description>

--- a/tests/Akkling.Tests/Akkling.Tests.fsproj
+++ b/tests/Akkling.Tests/Akkling.Tests.fsproj
@@ -29,10 +29,10 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FsCheck.Xunit" Version="2.14.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="FsCheck.Xunit" Version="2.16.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Latest Akka.NET release broke cluster sharding support due to a new method added to IMessageExtractor interface. With the addition of ShardId overload computed from entityId TypedMessageExtractor no longer provides the best fit for IMessageExtractor implementation but can still be used in with the new version of IMessageExtractor - the new ShardId overload uses messageHint to compute ShardId.

This fix should be considered a workaround backward compatible with existing Akkling client code. To take full advantage of the new version of IMessageExtractor TypedMessageExtractor constructor should be changed to accept extractor argument with a different function signature. Such change will break backward compatibility of spawnSharded method, so there should be considered a new function (with a different name) to spawn sharded actors.